### PR TITLE
Excel export-import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ nosetests.xml
 # Dont commit the db files
 mittab/backups/
 *.sqlite3
+
+# don't add IDEA/PyCharm files
+/.idea

--- a/mittab/apps/tab/forms.py
+++ b/mittab/apps/tab/forms.py
@@ -8,15 +8,26 @@ from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.core.exceptions import ValidationError
 from decimal import Decimal
 
+from django.utils.safestring import mark_safe
+
 from models import *
 
 class UploadBackupForm(forms.Form):
     file  = forms.FileField(label="Your Backup File")
 
+
 class UploadDataForm(forms.Form):
-    team_file = forms.FileField(label="Teams Data File", required=False)
-    judge_file = forms.FileField(label="Judge Data File", required=False)
-    room_file = forms.FileField(label="Room Data File", required=False)
+    """Creates the form for uploading files."""
+    team_file = forms.FileField(label=mark_safe('Teams Data File <br /><small>(Name, School, Seed [full, half, free, '
+                                                'none], D1 name, D1 status [varsity, novice, nov, n], D1 phone, '
+                                                'D1 prov, <br />D2 name, D2 [varsity, novice, nov, n], D2 phone, '
+                                                'D2 prov) <b>Note: Overwrites data for duplicate teams</b></small>'),
+                                required=False)
+    judge_file = forms.FileField(label=mark_safe('Judge Data File <br /><small>(name, rank, phone #, provider, '
+                                                 'school) <b>Note: Overwrites data for duplicate judges</b></small>'),
+                                 required=False)
+    room_file = forms.FileField(label=mark_safe('Room Data File <br /><small>(name, rank) <b>Note: Overwrites data for '
+                                                'duplicate rooms</b></small>'), required=False)
 
 
 class SchoolForm(forms.ModelForm):

--- a/mittab/apps/tab/template_views.py
+++ b/mittab/apps/tab/template_views.py
@@ -1,0 +1,6 @@
+from django.views.generic import TemplateView
+
+
+class ExportXlsView(TemplateView):
+    """Shows the template 'export_links.html'"""
+    template_name = 'export_links.html'

--- a/mittab/apps/tab/templates/403.html
+++ b/mittab/apps/tab/templates/403.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}ERROR!{% endblock %}
+{% block title %}403 Forbidden{% endblock %}
 
 {% block content %}
 <div style="text-align: center">

--- a/mittab/apps/tab/templates/base.html
+++ b/mittab/apps/tab/templates/base.html
@@ -24,7 +24,7 @@
             <div id="dialog" class="invisible" title="Please Confirm">Are you sure?</div>
             <div id="top_banner">
                 <!-- <img src="/static/images/title_banner.png" class="banner"> -->
-                <div class="welcome">MIT-TAB</div>
+                <div class="welcome" title="Monopolistic Tabulation">MIT-TAB</div>
             </div>
             {% if not no_navigation %}
             {% include "navigation.html" %}

--- a/mittab/apps/tab/templates/error.html
+++ b/mittab/apps/tab/templates/error.html
@@ -3,7 +3,7 @@
 {% block title %}ERROR!{% endblock %}
 
 {% block content %}
-<p style="color:red;"> {{ error_type }} {{ error_name }} ecountered an error!</p>
+<p style="color:red;"> {{ error_type }} {{ error_name }} encountered an error!</p>
 
 <p style="color:red;"> Reason for Error: {{error_info}} </p>
 {% endblock %}

--- a/mittab/apps/tab/templates/export_links.html
+++ b/mittab/apps/tab/templates/export_links.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}Export XLS file{% endblock %}
+{% block banner %}Export XLS file{% endblock %}
+{% block content %}
+
+    <p>Download links to dynamically generated and up-to-date XLS files each of which contains team, judge, and room
+        properties. These files are formatted so they can easily be re-imported using the <a href="/import_data">XLS
+            File Import</a> function. Note that when importing, the data in the Excel sheet will overwrite the data on
+        MIT-TAB's database.</p>
+
+    <div style="padding-left: 10px;">
+        <ul>
+            <li class="export_links"><a href="/export/teams">Export Teams</a></li>
+            <li class="export_links"><a href="/export/judges">Export Judges</a></li>
+            <li class="export_links"><a href="/export/rooms">Export Rooms</a></li>
+        </ul>
+    </div>
+
+    <p>These links can be used to export team and speaker statistics which may be useful in calculating the break or
+        speaker awards if your tournament uses a custom tabulation policy which differs from the standard ranking
+        provided by MIT-TAB, which uses total speaks, ranks; single-adjusted speaks, ranks; double-adjusted speaks,
+        ranks; opp-strength; coin-flip.</p>
+    <div style="padding-left: 10px;">
+        <ul>
+            <li class="export_links"><a href="/export/team-stats">Export Team Statistics</a></li>
+            <li class="export_links"><a href="/export/speaker-stats">Export Speaker Statistics</a></li>
+        </ul>
+    </div>
+{% endblock %}

--- a/mittab/apps/tab/templates/navigation.html
+++ b/mittab/apps/tab/templates/navigation.html
@@ -50,7 +50,8 @@
             <ul id = "sublist">
                 <li><a href="/admin">Admin Interface</a></li>
                 <li><a class="{% active request confirm_start_new_tourny %}" href="{{ confirm_start_new_tourny }}">New Tournament</a></li>
-                <li><a class="{% active request upload_data %}" href="{{ upload_data }}">File Data Upload</a></li>
+                <li><a class="{% active request upload_data %}" href="{{ upload_data }}">Import XLS File</a></li>
+                <li><a href="/export">Export XLS File</a></li>
             </ul>
         </li>
         <li><a class="{% active request tab_cards %}{% active request backup %}{% active request view_backups %}">Backups</a>

--- a/mittab/libs/data_import/export_xls_files.py
+++ b/mittab/libs/data_import/export_xls_files.py
@@ -1,0 +1,220 @@
+from django.contrib.auth.decorators import permission_required
+from django.http import HttpResponse
+from xlwt import Workbook
+
+from mittab.apps.tab.models import Team, Judge, Room, Debater
+from mittab.libs import tab_logic
+
+
+def _create_vn_str(novice_status):
+    """Creates varsity-novice status string from the integer pseudo-enum used by the model"""
+    if novice_status is 0: return "varsity"
+    if novice_status is 1: return "novice"
+    return novice_status
+
+
+@permission_required('tab.tab_settings.can_change', login_url="/403/")
+def export_teams(request):
+    """Exports teams as a new XLS file which is then streamed to an HTTP response. This file should always be
+    cross-compatible with the parsing system used in the import_teams file. """
+
+    book = Workbook('utf-8')
+    sheet = book.add_sheet('Teams')
+
+    # write headers
+    headers = ['Name', 'School', 'Seed', 'Debater 1 Name', 'D1 Status', 'D1 Phone#', 'D1 Provider', 'Debater 2 Name',
+               'D2 Status', 'D2 Phone#', 'D2 Provider']
+    for i in xrange(len(headers)):
+        sheet.write(0, i, headers[i])
+
+    # write rows
+    teams = Team.objects.all()
+    for i in xrange(len(teams)):
+
+        team = teams[i]
+        row = i + 1
+
+        name = team.name
+        school = team.school.name
+
+        # convert seed
+        # seed = 0 if unseeded, seed = 1 if free seed, seed = 2 if half seed, seed = 3 if full seed
+        seed = team.seed
+        if seed is 0:
+            seed = 'unseeded'
+        elif seed is 1:
+            seed = 'free'
+        elif seed is 2:
+            seed = 'half'
+        elif seed is 3:
+            seed = 'full'
+
+        debaters = team.debaters.all()
+        deb1_name = debaters[0].name
+        deb1_status = _create_vn_str(debaters[0].novice_status)  # 0 = Varsity, 1 = Novice
+        deb1_phone = debaters[0].phone
+        deb1_provider = debaters[0].provider
+
+        sheet.write(row, 0, name)
+        sheet.write(row, 1, school)
+        sheet.write(row, 2, seed)
+
+        sheet.write(row, 3, deb1_name)
+        sheet.write(row, 4, deb1_status)
+        sheet.write(row, 5, deb1_phone)
+        sheet.write(row, 6, deb1_provider)
+
+        if len(debaters) > 1:
+            deb2_name = debaters[1].name
+            deb2_status = _create_vn_str(debaters[1].novice_status)
+            deb2_phone = debaters[1].phone
+            deb2_prov = debaters[1].provider
+
+            sheet.write(row, 7, deb2_name)
+            sheet.write(row, 8, deb2_status)
+            sheet.write(row, 9, deb2_phone)
+            sheet.write(row, 10, deb2_prov)
+
+    # construct response
+    response = HttpResponse(content_type='application/vnd.ms-excel')
+    response['Content-Disposition'] = 'attachment; filename=mittab-teams.xls'
+    book.save(response)
+    return response
+
+
+@permission_required('tab.tab_settings.can_change', login_url="/403/")
+def export_judges(request):
+    """Exports judges to a XLS file which is then streamed to the recipient. This method should always be
+    cross-compatible with the import_judges file. """
+    book = Workbook('utf-8')
+    sheet = book.add_sheet('Judges')
+
+    # 0 name, 1 rank, 2 phone, 3 provider, 4+ schools
+    headers = ['Name', 'Rank', 'Phone', 'Provider', 'Schools']
+    for i in xrange(len(headers)):
+        sheet.write(0, i, headers[i])
+
+    judges = Judge.objects.all()
+    for i in xrange(len(judges)):
+        judge = judges[i]
+        row = i + 1
+
+        name = judge.name
+        rank = judge.rank
+        phone = judge.phone
+        provider = judge.provider
+        schools = judge.schools.all()
+
+        sheet.write(row, 0, name)
+        sheet.write(row, 1, rank)
+        sheet.write(row, 2, phone)
+        sheet.write(row, 3, provider)
+
+        for x in xrange(len(schools)):  # iterate through other school affiliations
+            sheet.write(row, x + 4, schools[x].name)
+
+    # construct response
+    response = HttpResponse(content_type='application/vnd.ms-excel')
+    response['Content-Disposition'] = 'attachment; filename=mittab-judges.xls'
+    book.save(response)
+    return response
+
+
+@permission_required('tab.tab_settings.can_change', login_url="/403/")
+def export_rooms(request):
+    """Exports rooms to an XLS file which is then streamed to the recipient. This method should always be
+    cross-compatible with the import_rooms file. """
+    book = Workbook('utf-8')
+    sheet = book.add_sheet('Rooms')
+
+    # 0 name, 1 rank, 2 phone, 3 provider, 4+ schools
+    headers = ['Name', 'Rank']
+    for i in xrange(len(headers)):
+        sheet.write(0, i, headers[i])
+
+    rooms = Room.objects.all()
+    for i in xrange(len(rooms)):
+        room = rooms[i]
+        row = i + 1
+        sheet.write(row, 0, room.name)
+        sheet.write(row, 1, room.rank)
+
+    # construct response
+    response = HttpResponse(content_type='application/vnd.ms-excel')
+    response['Content-Disposition'] = 'attachment; filename=mittab-rooms.xls'
+    book.save(response)
+    return response
+
+
+@permission_required('tab.tab_settings.can_change', login_url="/403/")
+def export_team_stats(request):
+    """Exports data as XLS for each team: win-loss record, total speaker points, total ranks, single-adjusted
+    speaker points, single-adjusted ranks, double-adjusted speaker points, double-adjusted ranks, and opposition
+    strength."""
+    book = Workbook('utf-8')
+    sheet = book.add_sheet('Team stats')
+
+    sheet.write(0, 0, 'If you are calculating the break off of these statistics, please pay attention to how you sort. '
+                      'In general, everything except ranks should be sorted from large to small.')
+
+    headers = ['team name','# wins', 'total speaker points', 'total ranks', 'single-adjusted speaker points',
+               'single-adjusted ranks', 'double-adjusted speaker points', 'double-adjusted ranks',
+               'opposition strength']
+    for i in xrange(len(headers)):
+        sheet.write(1, i, headers[i])
+
+    teams = Team.objects.all()
+    for i in xrange(len(teams)):
+        team, row = teams[i], i + 2
+        sheet.write(row, 0, team.name)
+        sheet.write(row, 1, tab_logic.tot_wins(team))
+        sheet.write(row, 2, tab_logic.tot_speaks(team))
+        sheet.write(row, 3, tab_logic.tot_ranks(team))
+        sheet.write(row, 4, tab_logic.single_adjusted_speaks(team))
+        sheet.write(row, 5, tab_logic.single_adjusted_ranks(team))
+        sheet.write(row, 6, tab_logic.double_adjusted_speaks(team))
+        sheet.write(row, 7, tab_logic.double_adjusted_ranks(team))
+        sheet.write(row, 8, tab_logic.opp_strength(team))
+
+    # construct response
+    response = HttpResponse(content_type='application/vnd.ms-excel')
+    response['Content-Disposition'] = 'attachment; filename=mittab-team-stats.xls'
+    book.save(response)
+    return response
+
+
+@permission_required('tab.tab_settings.can_change', login_url="/403/")
+def export_debater_stats(request):
+    """Exports data as XLS for each speaker: total speaker points, total ranks, single adjusted speaks, single adjusted
+    ranks, double adjusted speaks, double adjusted ranks, team performance, opposition strength. Automatically averages
+    for iron-men. """
+    book = Workbook('utf-8')
+    sheet = book.add_sheet('Team stats')
+
+    sheet.write(0, 0, 'If you are calculating the awards off these statistics, please pay attention to how you sort. '
+                      'In general, everything except ranks should be sorted from large to small.')
+
+    headers = ['debater name', 'total speaker points', 'total ranks', 'single-adjusted speaker points',
+               'single-adjusted ranks', 'double-adjusted speaker points', 'double-adjusted ranks',
+               'team performance (debater\'s team win#)', 'opposition strength']
+    for i in xrange(len(headers)):
+        sheet.write(1, i, headers[i])
+
+    debaters = Debater.objects.all()
+    for i in xrange(len(debaters)):
+        debater, row = debaters[i], i + 2
+        sheet.write(row, 0, debater.name)
+        sheet.write(row, 1, tab_logic.tot_speaks_deb(debater, average_ironmen=True))
+        sheet.write(row, 2, tab_logic.tot_ranks_deb(debater, True))
+        sheet.write(row, 3, tab_logic.single_adjusted_speaks_deb(debater))
+        sheet.write(row, 4, tab_logic.single_adjusted_ranks_deb(debater))
+        sheet.write(row, 5, tab_logic.double_adjusted_speaks_deb(debater))
+        sheet.write(row, 6, tab_logic.double_adjusted_ranks_deb(debater))
+        sheet.write(row, 7, tab_logic.tot_wins(Team.objects.filter(debaters__name=debater.name).first()))
+        sheet.write(row, 8, tab_logic.opp_strength(debater))
+
+    # construct response
+    response = HttpResponse(content_type='application/vnd.ms-excel')
+    response['Content-Disposition'] = 'attachment; filename=mittab-debater-stats.xls'
+    book.save(response)
+    return response

--- a/mittab/libs/data_import/import_judges.py
+++ b/mittab/libs/data_import/import_judges.py
@@ -18,78 +18,78 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #THE SOFTWARE.
 
-from mittab.apps.tab.models import *
-from mittab.apps.tab.forms import JudgeForm
-
 from decimal import *
 import xlrd
-from xlwt import Workbook
+
+from mittab.apps.tab.forms import JudgeForm
+from mittab.apps.tab.models import *
+
 
 def import_judges(fileToImport):
     try:
         sh = xlrd.open_workbook(filename=None, file_contents=fileToImport.read()).sheet_by_index(0)
     except:
-        return ["ERROR: Please upload an .xlsx file. This filetype is not compatible"]
-    num_judges = 0
+        return ["ERROR: Please upload an .xlsx file. This file type is not compatible"]
+    judge_entries = 0
     found_end = False
-    judge_errors = []
-    while found_end == False:
+    errors = []
+    while not found_end:
         try:
-            sh.cell(num_judges, 0).value
-            num_judges += 1
+            sh.cell(judge_entries, 0).value # find file end
+            judge_entries += 1
         except IndexError:
             found_end = True
 
-        #Verify sheet has required number of columns
+        # Verify sheet has required number of columns
         try:
             sh.cell(0, 1).value
-        except:
-            team_errors.append("ERROR: Insufficient Columns in sheet. No Data Read")
-            return team_errors
-    for i in range(1, num_judges):
-        #Load and validate Judge's Name
-        judge_name = sh.cell(i, 0).value
-        try:
-            Judge.objects.get(name=judge_name)
-            judge_errors.append(judge_name + ": Duplicate Judge Name")
-            continue
-        except:
-            pass
+        except IndexError:
+            errors.append("ERROR: Insufficient Columns in sheet. No Data Read")
+            return errors
 
-        #Load and validate judge_rank
+    for i in range(1, judge_entries):
+
+        # 0     name
+        # 1     rank
+        # 2     phone
+        # 3     provider
+        # 4+    schools
+
+        is_duplicate = False
+
+        # Load and validate Judge's Name
+        judge_name = sh.cell(i, 0).value
+        if Judge.objects.filter(name=judge_name).first() is not None:
+            errors.append(judge_name + ': duplicate judge name, overwriting')
+            is_duplicate = True
+
+        # Load and validate judge_rank
         judge_rank = sh.cell(i, 1).value
         try:
-            judge_rank = round(float(judge_rank), 2)
-        except:
-            judge_errors.append(judge_name + ": Rank not number")
+            judge_rank = Decimal(judge_rank)
+        except TypeError or ValueError:
+            errors.append(judge_name + ": Rank is not a number")
             continue
+
         if judge_rank > 100 or judge_rank < 0:
-            judge_errors.append(judge_name + ": Rank should be between 0-100")
+            errors.append(judge_name + ": Rank should be between 0-100")
             continue
 
-        #Because this data is not required, be prepared for IndexErrors
-        #or ValueErrors when int() attempts to parse empty string
-        try:
-            judge_phone = str(int(sh.cell(i, 2).value))
-        except (IndexError, ValueError) as e:
-            judge_phone = ''
-        try: 
-            judge_provider = sh.cell(i, 3).value
-        except IndexError:
-            judge_provider = ''
+        judge_phone = sh.cell(i, 2).value
+        judge_provider = sh.cell(i, 3).value
 
-        #iterate through schools until none are left
+        # iterate through schools until none are left
         cur_col = 4
         schools = []
-        while(True):
+        while True:
             try:
                 judge_school = sh.cell(i, cur_col).value
-                #If other judges have more schools but this judge doesn't, we get an empty string
-                #If blank, keep iterating in case user has a random blank column for some reason
-                if (judge_school != ''):
+                # If other judges have more schools but this judge doesn't, we get an empty string
+                # If blank, keep iterating in case user has a random blank column for some reason
+                if judge_school != '':
                     try:
-                        #Get id from the name because JudgeForm requires we use id
-                        s = School.objects.get(name__iexact=judge_school).id 
+                        # Get id from the name because JudgeForm requires we use id
+                        s = School.objects.get(name=judge_school).id
                         schools.append(s)
                     except IndexError:
                         break
@@ -99,20 +99,27 @@ def import_judges(fileToImport):
                             s.save()
                             schools.append(s.id)
                         except:
-                            judge_errors.append(judge_name + ': Invalid School')
+                            errors.append(judge_name + ': Invalid School')
                             continue
             except IndexError:
                 break
             cur_col += 1
 
-        data = {'name': judge_name, 'rank': judge_rank, 'phone': judge_phone, 'provider': judge_provider, 'schools': schools}
-        form = JudgeForm(data=data)
-        if (form.is_valid()):
-            form.save()
+        if is_duplicate:  # overwrite the parameters for that judge
+            judge = Judge.objects.get(name=judge_name)
+            judge.rank = judge_rank
+            judge.phone = judge_phone
+            judge.provider = judge_provider
+            judge.school = schools
+            judge.save()
+
         else:
-            error_messages = sum([ error[1] for error in form.errors.items() ], [])
-            error_string = ', '.join(error_messages)
-            judge_errors.append("%s: %s" % (judge_name, error_string))
+            form = JudgeForm(data={'name': judge_name, 'rank': judge_rank, 'phone': judge_phone,
+                                   'provider': judge_provider, 'schools': schools})
+            if form.is_valid():
+                form.save()
+            else:
+                print form.errors  # print errors of console so they can actually be debugged
+                errors.append(judge_name + ": Form invalid. Check inputs.")
 
-    return judge_errors
-
+    return errors

--- a/mittab/libs/data_import/import_teams.py
+++ b/mittab/libs/data_import/import_teams.py
@@ -18,11 +18,13 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #THE SOFTWARE.
 
-from mittab.apps.tab.models import *
-from mittab.apps.tab.forms import SchoolForm
-
+import collections
 import xlrd
-from xlwt import Workbook
+from django.core.exceptions import ObjectDoesNotExist
+
+from mittab.apps.tab.forms import SchoolForm
+from mittab.apps.tab.models import *
+
 
 def import_teams(fileToImport):
     try:
@@ -46,18 +48,35 @@ def import_teams(fileToImport):
             team_errors.append('ERROR: Insufficient Columns in Sheet. No Data Read')
             return team_errors
 
+    # verify no duplicate debaters, give error messages
+    deb_indicies = []
+    for i in range(1, num_teams):
+        deb_indicies.append((sh.cell(i, 3).value.strip(), i))  # tuple saves debater name and row
+        deb_indicies.append((sh.cell(i, 7).value.strip(), i))
+    deb_names = [i[0] for i in deb_indicies]
+    names_dict = collections.Counter(deb_names)
+    for deb_index in deb_indicies:
+        if names_dict.get(deb_index[0]) > 1:  # if dict says appears more than once
+            # inform that duplicate exists at location, report relevant information
+            row_num = deb_index[1]
+            msg = "Check for duplicate debater " + deb_index[0] + " in team " + sh.cell(row_num, 0).value + \
+                  ", on XLS file row " + str(row_num)
+            team_errors.append(msg)
+
     for i in range(1, num_teams):
 
+        # Name, School, Seed [full, half, free, none], D1 name, D1 v/n?, D1 phone, D1 prov,
+        # D2 name, D2 v/n?, D2 phone, D2 prov
+
+        # team name, check for duplicates
+        duplicate = False
         team_name = sh.cell(i, 0).value
         if team_name == '':
-            team_errors.append('Row ' + str(i) + ': Empty Team Name')
+            team_errors.append('Skipped row ' + str(i) + ': empty Team Name')
             continue
-        try:
-            Team.objects.get(name=team_name)
-            team_errors.append(team_name + ': Duplicate Team Name')
-            continue
-        except:
-            pass
+        if Team.objects.filter(name=team_name).first() is not None:  # inform that duplicates exist
+            duplicate = True
+            team_errors.append(team_name + ': duplicate team, overwriting data')
 
         school_name = sh.cell(i, 1).value.strip()
         try:
@@ -72,98 +91,100 @@ def import_teams(fileToImport):
                 continue
             team_school = School.objects.get(name__iexact=school_name)
 
-        team_seed = sh.cell(i,2).value.strip().lower()
-        if team_seed == 'full seed' or team_seed == 'full':
-            team_seed = 3
-        elif team_seed == 'half seed' or team_seed == 'half':
-            team_seed = 2
-        elif team_seed == 'free seed' or team_seed == 'free':
-            team_seed = 1
-        elif team_seed == 'unseeded' or team_seed == 'un' or team_seed == 'none' or team_seed == '':
-            team_seed = 0
-        else:
-            team_errors.append(team_name + ': Invalid Seed Value')
-            continue
+        # check seeds
+        team_seed, changed_seed = _create_seed(team_name=team_name, seed=sh.cell(i, 2).value.strip().lower())
+        if changed_seed:
+            team_errors.append('Changed ' + team_name + ' from "' + sh.cell(i, 2).value.strip().lower()
+                               + '" to unseeded. Note and confirm with school.')
 
-        deb1_name = sh.cell(i,3).value
-        if deb1_name == '':
-            team_errors.append(team_name + ': Empty Debater-1 Name')
-            continue
-        try:
-            Debater.objects.get(name=deb1_name)
-            team_errors.append(team_name + ': Duplicate Debater-1 Name')
-            continue
-        except:
-            pass
-        deb1_status = sh.cell(i,4).value.lower()
-        if deb1_status == 'novice' or deb1_status == 'nov' or deb1_status == 'n':
-            deb1_status = 1
-        else:
-            deb1_status = 0
-        deb1_phone = sh.cell(i,5).value
-        deb1_provider = sh.cell(i,6).value
+        deb1_name = sh.cell(i, 3).value.strip()
+        deb1_status = _create_status(sh.cell(i, 4).value.lower())
+        deb1_phone = sh.cell(i, 5).value.strip()
+        deb1_provider = sh.cell(i, 6).value.strip()
+        deb1, deb1_created = Debater.objects.get_or_create(name=deb1_name, novice_status=deb1_status, phone=deb1_phone,
+                                                           provider=deb1_provider)
 
-
-        iron_man = False
-        deb2_name = sh.cell(i,7).value
-        if deb2_name == '':
-            iron_man = True
-        if (not iron_man):
+        iron_man = True
+        deb2_name = sh.cell(i, 7).value.strip()
+        if deb2_name is not '':
+            iron_man = False
+            deb2_status = _create_status(sh.cell(i, 8).value.lower())
             try:
-                Debater.objects.get(name=deb2_name)
-                team_errors.append(team_name + ': Duplicate Debater-2 Name')
-                continue
-            except:
-                pass
-            deb2_status = sh.cell(i,8).value.lower()
-            if deb2_status == 'novice' or deb2_status == 'nov' or deb2_status == 'n':
-                deb2_status = 1
-            else:
-                deb2_status = 0
-
-            #Since this is not required data and at the end of the sheet, be ready for index errors
-            try: 
-                deb2_phone = sh.cell(i,9).value
+                deb2_phone = sh.cell(i, 9).value
             except IndexError:
                 deb2_phone = ''
             try:
                 deb2_provider = sh.cell(i,10).value
             except IndexError:
                 deb2_provider = ''
+            deb2, deb2_created = Debater.objects.get_or_create(name=deb2_name, novice_status=deb2_status,
+                                                               phone=deb2_phone,
+                                                               provider=deb2_provider)
 
-
-        #Save Everything
-        try:
-            deb1 = Debater(name = deb1_name, novice_status = deb1_status, phone = deb1_phone, provider = deb1_provider)
-            deb1.save()
-        except:
-            team_errors.append(team_name + ': Unkown Error Saving Debater 1')
-            continue
-        if (not iron_man):
-            try:
-                deb2 = Debater(name = deb2_name, novice_status = deb2_status, phone = deb2_phone, provider = deb2_provider)
-                deb2.save()
-            except:
-                team_errors.append(team_name + ': Unkown Error Saving Debater 2')
-                team_errors.append('        WARNING: Debaters on this team may be added to database. ' +
-                                    'Please Check this Manually')
-                continue
-        
-        team = Team(name=team_name, school=team_school, seed=team_seed)
-        try:
+        if not duplicate:  # create new team
+            team = Team(name=team_name, school=team_school, seed=team_seed)
             team.save()
             team.debaters.add(deb1)
-            if (not iron_man):
+            if not iron_man:
                 team.debaters.add(deb2)
             else:
-                team_errors.append(team_name + ": Detected to be Iron Man - Still added successfully")
+                team_errors.append(team_name + ': Team is an iron-man, added successfully')
             team.save()
-        except:
-            team_errors.append(team_name + ': Unknown Error Saving Team')
-            team_errors.append('        WARNING: Debaters on this team may be added to database. ' +
-                                'Please Check this Manually')
+
+        else:  # update the team
+            team = Team.objects.get(name=team_name)
+            team.school = team_school
+            team.seed = team_seed
+
+            team.debaters.clear()
+            team.debaters.add(deb1)
+            if not iron_man:
+                team.debaters.add(deb2)
+            else:
+                team_errors.append(team_name + ': Team is an iron-man, added successfully')
+            team.save()
 
     return team_errors
 
-    
 
+def _create_status(status):
+    """Translates the string for varsity-novice status into MIT-TAB's integer pseudo-enum"""
+    if status == 'novice' or status == 'nov' or status == 'n':
+        return 1
+    else:
+        return 0
+
+
+def _create_seed(team_name, seed):
+    """Translates the string version of the seed into the pseudo-enum. Checks for duplicate free seeds and changes it
+    as necessary. Also notes that change so a message can be returned.
+    :type team_name: str
+    :type seed: str
+    :return tuple with the integer version of the seed and whether that team's seed was changed
+    """
+    seed_int = 0
+    seed_changed = False
+
+    if seed == 'full seed' or seed == 'full':
+        seed_int = 3
+    elif seed == 'half seed' or seed == 'half':
+        seed_int = 2
+    elif seed == 'free seed' or seed == 'free':
+        seed_int = 1
+
+        multiple_free_seeds = False
+        try:
+            school_name = Team.objects.get(name=team_name).school  # get school_name
+            for team in Team.objects.filter(school=school_name).all():  # get teams with that name
+                if int(team.seed) == 1:  # 1 is the free seed
+                    if team.name != team_name:  # if there is a free seed already, change and note change
+                        multiple_free_seeds = True
+
+        except ObjectDoesNotExist:
+            pass
+
+        if multiple_free_seeds:  # force free, note this
+            seed_changed = True
+            seed_int = 0
+
+    return seed_int, seed_changed

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -7,6 +7,8 @@ import apps.tab.judge_views as judge_views
 import apps.tab.team_views as team_views
 import apps.tab.debater_views as debater_views
 import apps.tab.pairing_views as pairing_views
+from mittab.apps.tab import template_views
+from mittab.libs.data_import import export_xls_files
 
 from django.contrib import admin
 admin.autodiscover()
@@ -103,6 +105,12 @@ urlpatterns = [
     url(r'^backup/(.+)/$', pairing_views.view_backup),
     url(r'^upload_backup/$', pairing_views.upload_backup),
 
-    # Data Upload
-    url(r'^import_data/$', views.upload_data)
+    # Data upload and download
+    url(r'^import_data/$', views.upload_data),
+    url(r'^export/$', template_views.ExportXlsView.as_view()),
+    url(r'^export/teams', export_xls_files.export_teams),
+    url(r'^export/judges', export_xls_files.export_judges),
+    url(r'^export/rooms', export_xls_files.export_rooms),
+    url(r'^export/team-stats', export_xls_files.export_team_stats),
+    url(r'^export/speaker-stats', export_xls_files.export_debater_stats)
 ]


### PR DESCRIPTION
Implemented some import-export stuff from Excel. There is now a page
where you can download dynamically generated excel files that accompany
the rooms, judges, and teams which were imported, along with excel
files containing team and speaker statistics so tournaments which don’t
follow the standard MIT-TAB ranking can get the data they want.

In the upload data form, I’ve added text which tells people what the
headers are, so they don’t have to go digging in the manual to find out.

The import system has also been reworked so that it overwrites
preexisting data rather than simply skipping the entry. This means that
changes applied in some excel document can be applied en-masse by
importing the changed document.

I've tried to keep changes outside this to a minimum, but adding it to the level that one can actually access it via the web interface means digging through the template files. The main changes are the `import_x` files, which I rewrote; the `export_xls_files` which I wrote; and the template changes.

The way the template change is structured is that it primarily just goes to a view unconnected with the other ones. I think that is easier for you to check. It could trivially be put back into the main files.