### PR TITLE
Delete no-shows for teams once a round is saved

### DIFF
--- a/mittab/apps/tab/models.py
+++ b/mittab/apps/tab/models.py
@@ -184,6 +184,16 @@ class Round(models.Model):
     def __unicode__(self):
         return "Round " + str(self.round_number) + " between " + str(self.gov_team) + " (GOV) and " + str(self.opp_team) + " (OPP)"
 
+    def save(self):
+        no_shows = NoShow.objects.filter(
+                round_number=self.round_number
+                no_show_team__in=[self.gov_team, self.opp_team])
+
+        if no_shows:
+            no_shows.delete()
+
+        super(Round, self).save()
+
     def delete(self):
         rounds = RoundStats.objects.filter(round=self)
         for rs in rounds:

--- a/mittab/apps/tab/models.py
+++ b/mittab/apps/tab/models.py
@@ -186,7 +186,7 @@ class Round(models.Model):
 
     def save(self):
         no_shows = NoShow.objects.filter(
-                round_number=self.round_number
+                round_number=self.round_number,
                 no_show_team__in=[self.gov_team, self.opp_team])
 
         if no_shows:


### PR DESCRIPTION
One option for addressing https://github.com/jolynch/mit-tab/issues/124

Alternatively, tab could just ignore the no-shows if there is a round.