### PR TITLE
Feat/user page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,10 @@ lib
 lib64
 __pycache__
 *.DS_STORE
-admin
-css
-images
-javascript
+/admin
+/css
+/images
+/javascript
 
 # Installer logs
 pip-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ lib
 lib64
 __pycache__
 *.DS_STORE
+admin
+css
+images
+javascript
 
 # Installer logs
 pip-log.txt

--- a/mittab/apps/tab/middleware.py
+++ b/mittab/apps/tab/middleware.py
@@ -4,17 +4,23 @@ from django.contrib.auth.views import login
 from django.http import HttpResponseRedirect
 from django.core.cache import cache
 
-login_white_list = ('/accounts/login/', '/static/css/stylesheet.css',
+string_white_list = ('/accounts/login/', '/static/css/stylesheet.css',
         '/static/images/title_banner.png', '/pairings/pairinglist/', '/stat',
         '/e_ballots/', '/pairings/missing_ballots/')
 
-e_ballot_regex = re.compile("/e_ballots/\S+")
+regex_white_list = (
+    re.compile("/e_ballots/\S+"),
+    re.compile("/public_status/team_name/([\w-]+)/"),
+    re.compile("/public_status/debater_name/([\w-]+)/"),
+)
+
 
 class Login:
     "This middleware requires a login for every view"
     def process_request(self, request):
-        whitelisted = (request.path in login_white_list) or \
-                e_ballot_regex.match(request.path)
+
+        whitelisted = any(request.path == elem for elem in string_white_list) or \
+                      any(elem.fullmatch(request.path) for elem in regex_white_list)
 
         if not whitelisted and request.user.is_anonymous():
             if request.POST:

--- a/mittab/apps/tab/middleware.py
+++ b/mittab/apps/tab/middleware.py
@@ -10,8 +10,7 @@ string_white_list = ('/accounts/login/', '/static/css/stylesheet.css',
 
 regex_white_list = (
     re.compile("/e_ballots/\S+"),
-    re.compile("/public_status/team_name/([\w-]+)"),
-    re.compile("/public_status/debater_name/([\w-]+)"),
+    re.compile("/public_status/(\d+)"),
 )
 
 
@@ -19,7 +18,7 @@ class Login:
     "This middleware requires a login for every view"
     def process_request(self, request):
 
-        whitelisted = any(request.path == elem for elem in string_white_list) or \
+        whitelisted = request.path in string_white_list or \
                       any(elem.match(request.path) for elem in regex_white_list)
 
         if not whitelisted and request.user.is_anonymous():

--- a/mittab/apps/tab/middleware.py
+++ b/mittab/apps/tab/middleware.py
@@ -10,8 +10,8 @@ string_white_list = ('/accounts/login/', '/static/css/stylesheet.css',
 
 regex_white_list = (
     re.compile("/e_ballots/\S+"),
-    re.compile("/public_status/team_name/([\w-]+)/"),
-    re.compile("/public_status/debater_name/([\w-]+)/"),
+    re.compile("/public_status/team_name/([\w-]+)"),
+    re.compile("/public_status/debater_name/([\w-]+)"),
 )
 
 
@@ -20,7 +20,7 @@ class Login:
     def process_request(self, request):
 
         whitelisted = any(request.path == elem for elem in string_white_list) or \
-                      any(elem.fullmatch(request.path) for elem in regex_white_list)
+                      any(elem.match(request.path) for elem in regex_white_list)
 
         if not whitelisted and request.user.is_anonymous():
             if request.POST:

--- a/mittab/apps/tab/templates/base.html
+++ b/mittab/apps/tab/templates/base.html
@@ -34,7 +34,7 @@
                 {% block content %}{% endblock %}
                 {% block footer %}
                 <hr>
-                <p>Need help? Check out <a href="https://github.com/jolynch/mit-tab/wiki">the wiki.</a></p>
+                <p>Need help? Check out <a href="http://mit-tab.readthedocs.io">the wiki.</a></p>
                 <p>MIT-TAB, published under the MIT License by Joey Lynch and Julia Boortz</p>
                 {% endblock %}
         </div>

--- a/mittab/apps/tab/templates/base.html
+++ b/mittab/apps/tab/templates/base.html
@@ -13,6 +13,7 @@
     <script type="text/javascript" src="/static/javascript/bootstrap.js"></script>
     <script type="text/javascript" src="/static/admin/js/admin/RelatedObjectLookups.js"></script>
 
+    {% block headers %}{% endblock %}
 
     <title>{% block title %}{% endblock %}</title>
 </head>

--- a/mittab/apps/tab/templates/public_status.html
+++ b/mittab/apps/tab/templates/public_status.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %} Public Status for {{ team_name }} {% endblock %}
+
+{% block content %}
+  {% if pairing_exists %}
+    {% if bye %}
+      
+      {{team_name}} is on a bye this round.
+      
+    {% else %}
+    
+      {{team_name}} will {{gov_or_opp}} next round against {{other_team}}
+      in {{room}}, judged by {{judges}}.
+      
+    {% endif %}
+  {% else %}
+
+    Round {{round_number}} does not yet have a valid pairing. Please wait until
+    your tournament directors release a valid pairing before viewing this page.
+
+  {% endif %}
+{% endblock %}

--- a/mittab/apps/tab/templates/registration/login.html
+++ b/mittab/apps/tab/templates/registration/login.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 
 {% block content %}
-
+  
+  <script type="text/javascript" src="/static/javascript/login.js"></script>
+  
   {% if form.errors %}
     <p class="error">Sorry, that's not a valid username or password</p>
   {% endif %}
@@ -13,7 +15,7 @@
   </div>
 
   <div class="row-fluid">
-    <div class="span6">
+    <div class="span4">
       <h3> Tab Staff Login </h3>
       <form action="" method="post" class="form-horizontal">{% csrf_token %}
         <div class="control-group">
@@ -26,7 +28,8 @@
         <input type="hidden" name="next" value="{{ next|escape }}" />
       </form>
     </div>
-    <div class="span6">
+    
+    <div class="span4">
       <h3> Participant Access </h3>
       <div class="control-group">
         <a class="btn btn-large btn-info" href="/pairings/pairinglist/">
@@ -47,6 +50,24 @@
           Submit an e-ballot
         </a>
       </div>
+    </div>
+    
+    <div class="span4">
+      <h3> Next Round Look-up </h3>
+      
+      <div class="control-group">
+        
+        <label for="debater">Next Round for Debater:</label>
+        <input type="text" name="debater" value="" id="debater" placeholder="John Doe">          
+        <button class="btn inline"  id="debater_btn"> Check Team </button>
+        
+        <br> <br>
+        
+        <label for="debater">Next Round for Team:</label>
+        <input type="text" name="team" value="" id="team" placeholder="Team name">
+        <button class="btn inline"  id="team_btn"> Check Team </button>
+
+      </div> 
     </div>
   </div>
 

--- a/mittab/apps/tab/templates/registration/login.html
+++ b/mittab/apps/tab/templates/registration/login.html
@@ -1,9 +1,13 @@
 {% extends "base.html" %}
 
+{% block headers %}
+<script type="text/javascript" src="/static/javascript/login.js"></script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.6-rc.0/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.6-rc.0/js/select2.min.js"></script>
+{% endblock %}
+
 {% block content %}
-  
-  <script type="text/javascript" src="/static/javascript/login.js"></script>
-  
+    
   {% if form.errors %}
     <p class="error">Sorry, that's not a valid username or password</p>
   {% endif %}
@@ -57,15 +61,15 @@
       
       <div class="control-group">
         
-        <label for="debater">Next Round for Debater:</label>
-        <input type="text" name="debater" value="" id="debater" placeholder="John Doe">          
-        <button class="btn inline"  id="debater_btn"> Check Team </button>
+        <select id="teams-lookup">
+          
+          {% for team in teams %}
+          <option value={{team.0}}> {{team.1}} </option>
+          {% endfor %}
+
+        </select>
         
-        <br> <br>
-        
-        <label for="debater">Next Round for Team:</label>
-        <input type="text" name="team" value="" id="team" placeholder="Team name">
-        <button class="btn inline"  id="team_btn"> Check Team </button>
+        <button class="btn inline"  id="team_btn"> Check </button> 
 
       </div> 
     </div>

--- a/mittab/apps/tab/views.py
+++ b/mittab/apps/tab/views.py
@@ -25,7 +25,8 @@ def index(request):
     return render_to_response('index.html',locals(),context_instance=RequestContext(request))
 
 def tab_login(request):
-    return login(request, extra_context={'no_navigation': True})
+    teams = [(team.pk, team.name) for team in Team.objects.order_by('name')]
+    return login(request, extra_context={'no_navigation': True, 'teams': teams})
 
 def render_403(request):
     t = loader.get_template('403.html')

--- a/mittab/static/javascript/login.js
+++ b/mittab/static/javascript/login.js
@@ -1,0 +1,14 @@
+$(document).ready(() => { 
+  $("#teams-lookup").select2();
+  
+  $('.select2-selection').on('keyup', ((event) => {
+    if (event.keyCode === 13) {
+        $("#team_btn").click();
+    }
+  }));
+
+  $('#team_btn').click(() => {
+    val = document.getElementById('teams-lookup').value;
+    window.location.href = '/public_status/' + val + '/';
+  });
+});

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -101,7 +101,6 @@ urlpatterns = [
     url(r'^e_ballots/$', pairing_views.e_ballot_search),
     url(r'e_ballots/(\S+)/$', pairing_views.enter_e_ballot),
 
-
     # Backups
     url(r'^backup/restore/(.+)/$', pairing_views.restore_backup),
     url(r'^backup/download/(.+)/$', pairing_views.download_backup),
@@ -109,5 +108,9 @@ urlpatterns = [
     url(r'^upload_backup/$', pairing_views.upload_backup),
 
     # Data Upload
-    url(r'^import_data/$', views.upload_data)
+    url(r'^import_data/$', views.upload_data),
+    
+    # Publicly accessible personal pages
+    url(r'^public_status/team_name/([\w-]+)/', team_views.public_status_by_team),
+    url(r'^public_status/debater_name/([\w-]+)/', team_views.public_status_by_debater),
 ]

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -111,6 +111,5 @@ urlpatterns = [
     url(r'^import_data/$', views.upload_data),
     
     # Publicly accessible personal pages
-    url(r'^public_status/team_name/([\w-]+)/', team_views.public_status_by_team),
-    url(r'^public_status/debater_name/([\w-]+)/', team_views.public_status_by_debater),
+    url(r'^public_status/(\d+)/$', team_views.public_status),
 ]


### PR DESCRIPTION
This is copy-pasted from the commit message:

Introduce a page at /public_status/team_name/<team_name>/ and 
/public_status/debater_name/<debater_name>/ which displays some 
information teams will want about the upcoming round. Uses the same 
check as /pairings/pairinglist/ to ensure pairings are published and 
ought be publicly accessible. To provide user access to these pages, add 
a new Next Round Look-up section to the login page with text-boxes 
linking to lookup by debater name or team name.