### PR TITLE
Add ability to export as a Tournament Archive

### DIFF
--- a/mittab/apps/tab/archive.py
+++ b/mittab/apps/tab/archive.py
@@ -1,0 +1,150 @@
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+from mittab.apps.tab.models import School, Team, Judge, Room, Round
+
+DEBATE_ID_PREFIX = "D"
+ROOM_ID_PREFIX = "V"
+SPEAKER_ID_PREFIX = "S"
+TEAM_ID_PREFIX = "T"
+JUDGE_ID_PREFIX = "A"
+SCHOOL_ID_PREFIX = "I"
+SPEAKER_STATUS_PREFIX = "SC"
+
+
+class ArchiveExporter:
+
+    def __init__(self, name):
+        self.name = name
+        self.root = None
+
+    def export_tournament(self):
+        self.root = Element("tournament", {"name": self.name})
+
+        self.add_rounds()
+        self.add_participants()
+        self.add_schools()
+        self.add_rooms()
+        self.add_categories()
+
+        return tostring(self.root)
+
+    def add_rounds(self):
+        pos = ["pm", "lo", "mg", "mo"]
+        qs = Round.objects.all().order_by("round_number").prefetch_related(
+            "judges", "roundstats_set")
+
+        cur_round = None
+        r_tag = None
+        for debate in qs:
+            if debate.round_number != cur_round:
+                r_tag = SubElement(self.root, "round", {
+                    "name": "Round %s" % debate.round_number
+                })
+                cur_round = debate.round_number
+
+            adjs = " ".join(
+                [JUDGE_ID_PREFIX + str(j.id) for j in debate.judges.all()])
+            d_tag = SubElement(r_tag, "debate", {
+                "id": DEBATE_ID_PREFIX + str(debate.id),
+                "chair": JUDGE_ID_PREFIX + str(debate.chair_id),
+                "adjudicators": adjs,
+                "venue": ROOM_ID_PREFIX + str(debate.room_id)
+            })
+
+            gov_tag = SubElement(d_tag, "side", {
+                "team": TEAM_ID_PREFIX + str(debate.gov_team_id)
+            })
+            opp_tag = SubElement(d_tag, "side", {
+                "team": TEAM_ID_PREFIX + str(debate.opp_team_id)
+            })
+
+            if debate.victor == Round.GOV_VIA_FORFEIT or \
+                    debate.victor == Round.ALL_DROP:
+                opp_tag.set("forfeit", "True")
+            elif debate.victor == Round.OPP_VIA_FORFEIT or \
+                    debate.victor == Round.ALL_DROP:
+                gov_tag.set("forfeit", "True")
+
+            team_points = [0, 0] # Gov, Opp
+            stats = sorted(list(debate.roundstats_set.all().values()),
+                           key=lambda x: pos.index(x["debater_role"]))
+
+            if debate.victor == Round.GOV or debate.victor == Round.OPP:
+                for i, speech in enumerate(stats):
+                    side_tag = gov_tag if i % 2 == 0 else opp_tag
+                    team_points[i % 2] += speech["speaks"]
+                    speech_tag = SubElement(side_tag, "speech", {
+                        "speaker": SPEAKER_ID_PREFIX + str(speech["debater_id"]),
+                        "reply": "False"
+                    })
+                    ballot = SubElement(speech_tag, "ballot", {
+                        "adjudicators": adjs,
+                        "rank": str(speech["ranks"]),
+                        "ignored": "False"
+                    })
+                    ballot.text = str(speech["speaks"])
+
+            gov_win = [Round.GOV, Round.GOV_VIA_FORFEIT, Round.ALL_WIN]
+            gov_rank = "1" if debate.victor in gov_win else "2"
+            gov_ballot = SubElement(gov_tag, "ballot", {
+                "adjudicators": adjs, "rank": gov_rank})
+            gov_ballot.text = str(team_points[0])
+
+            opp_win = [Round.OPP, Round.OPP_VIA_FORFEIT, Round.ALL_WIN]
+            opp_rank = "1" if debate.victor in opp_win else "2"
+            opp_ballot = SubElement(opp_tag, "ballot", {
+                "adjudicators": adjs, "rank": opp_rank})
+            opp_ballot.text = str(team_points[1])
+
+    def add_participants(self):
+        participants_tag = SubElement(self.root, "participants")
+
+        for team in Team.objects.all().prefetch_related("debaters"):
+            team_tag = SubElement(participants_tag, "team", {
+                "id": TEAM_ID_PREFIX + str(team.id),
+                "name": team.name
+            })
+
+            institutions = SCHOOL_ID_PREFIX + str(team.school_id)
+            if team.hybrid_school_id is not None:
+                institutions += " " + SCHOOL_ID_PREFIX + str(team.hybrid_school_id)
+
+            for debater in team.debaters.all():
+                debater_tag = SubElement(team_tag, "speaker", {
+                    "id": SPEAKER_ID_PREFIX + str(debater.id),
+                    "categories": SPEAKER_STATUS_PREFIX + str(debater.novice_status),
+                    "institutions": institutions
+                })
+                debater_tag.text = debater.name
+
+        for judge in Judge.objects.all().prefetch_related("schools"):
+            SubElement(participants_tag, "adjudicator", {
+                "id": JUDGE_ID_PREFIX + str(judge.id),
+                "name": judge.name,
+                "score": str(judge.rank),
+                "institutions": " ".join(
+                    [SCHOOL_ID_PREFIX + str(s.id) for s in judge.schools.all()])
+            })
+
+    def add_schools(self):
+        for school in School.objects.all():
+            school_tag = SubElement(self.root, "institution", {
+                "id": SCHOOL_ID_PREFIX + str(school.id),
+                "reference": school.name
+            })
+            school_tag.text = school.name
+
+    def add_rooms(self):
+        for room in Room.objects.all():
+            room_tag = SubElement(self.root, "venue", {
+                "id": ROOM_ID_PREFIX + str(room.id),
+                "score": str(room.rank)
+            })
+            room_tag.text = room.name
+
+    def add_categories(self):
+        for i, name in enumerate(["Varsity", "Novice"]):
+            sc_tag = SubElement(self.root, "speaker-category", {
+                "id": SPEAKER_STATUS_PREFIX + str(i)
+            })
+            sc_tag.text = name

--- a/mittab/apps/tab/views.py
+++ b/mittab/apps/tab/views.py
@@ -1,8 +1,10 @@
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.views import login
 from django.contrib.auth import logout
+from django.http import HttpResponse
 from django.shortcuts import render
 
+from mittab.apps.tab.archive import ArchiveExporter
 from mittab.apps.tab.forms import SchoolForm, RoomForm, UploadDataForm, ScratchForm
 from mittab.apps.tab.helpers import redirect_and_flash_error, \
         redirect_and_flash_success
@@ -306,3 +308,16 @@ def upload_data(request):
             "room_info": room_info,
             "scratch_info": scratch_info
         })
+
+
+@permission_required("tab.tab_settings.can_change", login_url="/403/")
+def generate_archive(request):
+    tournament_name = request.META["SERVER_NAME"].split(".")[0]
+    filename = tournament_name + ".xml"
+
+    xml = ArchiveExporter(tournament_name).export_tournament()
+
+    response = HttpResponse(xml, content_type="text/xml; charset=utf-8")
+    response["Content-Length"] = len(xml)
+    response["Content-Disposition"] = "attachment; filename=%s" % filename
+    return response

--- a/mittab/templates/base/_navigation.html
+++ b/mittab/templates/base/_navigation.html
@@ -16,6 +16,7 @@
 {% url "view_teams" as view_teams%}
 {% url "rank_teams_ajax" as rank_teams %}
 {% url "all_tab_cards" as tab_cards %}
+{% url "download_archive" as download_archive %}
 
 {% url "enter_debater" as enter_debater %}
 {% url "view_debaters" as view_debaters %}
@@ -63,7 +64,7 @@
         </li>
 
         <li class="nav-item dropdown">
-          <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request tab_cards %}{% active request backup %}{% active request view_backups %}">
+          <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request tab_cards %}{% active request backup %}{% active request view_backups %}{%active request download_archive %}">
             Backups
           </a>
 
@@ -71,6 +72,7 @@
             <a class="dropdown-item {%active request view_backups %}" href="{{ view_backups }}">View Backups</a>
             <a class="dropdown-item {%active request backup %}" href="{{ backup }}">Backup Current</a>
             <a class="dropdown-item {%active request tab_cards %}" href="{{ tab_cards }}">View Tab Cards</a>
+            <a class="dropdown-item {%active request download_archive %}" href="{{ download_archive }}" title="DebateXML is an archive format to preserve tournaments and perform analyses.">Create DebateXML</a>
           </div>
         </li>
 

--- a/mittab/templates/navigation.html
+++ b/mittab/templates/navigation.html
@@ -16,6 +16,7 @@
 {% url "view_teams" as view_teams%}
 {% url "rank_teams_ajax" as rank_teams %}
 {% url "all_tab_cards" as tab_cards %}
+{% url "download_archive" as download_archive %}
 
 {% url "enter_debater" as enter_debater %}
 {% url "view_debaters" as view_debaters %}
@@ -55,11 +56,12 @@
                 <li><a class="{% active request batch_checkin %}" href="{{ batch_checkin }}">Batch Judge Checkin</a></li>
             </ul>
         </li>
-        <li><a class="{% active request tab_cards %}{% active request backup %}{% active request view_backups %}">Backups</a>
+        <li><a class="{% active request tab_cards %}{% active request backup %}{% active request view_backups %}{%active request download_archive %}">Backups</a>
             <ul id = "sublist">
                 <li><a class="{%active request view_backups %}" href="{{ view_backups }}">View Backups</a></li>
                 <li><a class="{%active request backup %}" href="{{ backup }}">Backup Current</a></li>
                 <li><a class="{%active request tab_cards %}" href="{{ tab_cards }}">View Tab Cards</a></li>
+                <li><a class="{%active request download_archive %}" href="{{ download_archive }}">Create DebateXML</a></li>
             </ul>
         </li>
         <li><a class="{% active request view_scratches %}" href="{{ view_scratches }}">Scratches</a>

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -166,7 +166,10 @@ urlpatterns = [
         name="upload_backup"),
 
     # Data Upload
-    url(r"^import_data/$", views.upload_data, name="upload_data")
+    url(r"^import_data/$", views.upload_data, name="upload_data"),
+
+    # Tournament Archive
+    url(r"^archive/download/$", views.generate_archive, name="download_archive")
 ]
 
 handler403 = "mittab.apps.tab.views.render_403"


### PR DESCRIPTION
The Tournament Archive or DebateXML is an XML-based format for the interchange of debate tournament data. Its schema is currently under review in TabbycatDebate/dta-spec#4.

This commit adds an admin form to export the site's data through that specification for archival and analysis. The page is available through `/archive/download/`, which asks for some supplementary details, such as the tournament's name.

A link to the form should be in the navigation; however, it doesn't seem to be there.

Byes are not yet handled.