### PR TITLE
Fix typo in Docs

### DIFF
--- a/docs/Before-Round-1.md
+++ b/docs/Before-Round-1.md
@@ -15,7 +15,7 @@ Whenever you pair a round the scratches will be automatically generated and you
 will be able to view them from the scratch view. Do not worry if they don't
 show up in the scratches view prior to pairing.
 
-Discrtionary Scratch: Navigate to either the judge page or team page,
+Discretionary Scratch: Navigate to either the judge page or team page,
 click on the "Scratches for <Name>" button at the bottom of the page.
 Then click the "Add Scratch" button.  This workflow for judges is shown below:
 


### PR DESCRIPTION
From ea13284691721bae3d36b162e5a25b8c67aebe53: "Discrtionary" -> "Discretionary"