### PR TITLE
Change judge weights so high-ranked judges are always preferred to lower ones

### DIFF
--- a/mittab/libs/assign_judges.py
+++ b/mittab/libs/assign_judges.py
@@ -40,12 +40,8 @@ def add_judges(pairings, judges, panel_points):
             for (pairing_i, pairing) in enumerate(group):
                 if not judge_conflict(judge, pairing.gov_team,
                                       pairing.opp_team):
-                    print("Adding edge %s <> %s - %d" % (judge.name, pairing_i,
-                            calc_weight(judge_i, pairing_i)))
                     graph_edges.append((pairing_i, judge_i + len(group),
                                         calc_weight(judge_i, pairing_i)))
-                else:
-                    print("Conflict %s" % judge.name)
         judge_assignments = mwmatching.maxWeightMatching(graph_edges,
                                                          maxcardinality=True)
         # If there is no possible assignment of chairs, raise an error

--- a/mittab/libs/assign_judges.py
+++ b/mittab/libs/assign_judges.py
@@ -40,8 +40,12 @@ def add_judges(pairings, judges, panel_points):
             for (pairing_i, pairing) in enumerate(group):
                 if not judge_conflict(judge, pairing.gov_team,
                                       pairing.opp_team):
+                    print("Adding edge %s <> %s - %d" % (judge.name, pairing_i,
+                            calc_weight(judge_i, pairing_i)))
                     graph_edges.append((pairing_i, judge_i + len(group),
                                         calc_weight(judge_i, pairing_i)))
+                else:
+                    print("Conflict %s" % judge.name)
         judge_assignments = mwmatching.maxWeightMatching(graph_edges,
                                                          maxcardinality=True)
         # If there is no possible assignment of chairs, raise an error
@@ -173,12 +177,7 @@ def calc_weight(judge_i, pairing_i):
     We want small negative numbers to be preferred to large negative numbers
 
     """
-    if judge_i < pairing_i:
-        # if the judge is highly ranked, we can have them judge a lower round
-        # if we absolutely have to
-        return judge_i - pairing_i
-    else:
-        return -1 * (judge_i - pairing_i)**2
+    return -1 * abs(judge_i - (-1 * pairing_i))
 
 
 def calc_weight_panel(judges):


### PR DESCRIPTION
Before, the weighting system placed a high priority on placing judges in equally-matched rooms. Now, the algorithm should still prefer that, but it will always prefer a higher ranked judge. Some examples. Here is an example of a major issue which occurred with the previous algorithm:

Say 2 judges are conflicted from every room except the 10th-best room. If 1 judge is the 10th-best judge, and the other is the 1st-best judge, the weight for the 10th best judge would be `0` and for the 1st-best it would be `-9`. This seems wrong, as we would prefer the best judge be paired in.

The calculation of `-1 * abs(judge_i - (-1 * pairing_i))` solves this problem because:

 * For all rounds, the highest-ranked judge will always be preferred to a lower-ranked judge
 * We still preserve power-pairing because high-ranked judges have preferable weights in high-ranked rooms