### PR TITLE
Logout button

### DIFF
--- a/mittab/templates/base/_navigation.html
+++ b/mittab/templates/base/_navigation.html
@@ -1,6 +1,7 @@
 {% load tags %}
 
 {% url "index" as home %}
+{% url "logout" as logout %}
 
 {% url "enter_school" as enter_school %}
 {% url "view_schools" as view_schools %}
@@ -42,7 +43,7 @@
     </button>
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav mr-auto order-0">
         <li class="nav-item dropdown">
           <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request pair_round %}{% active request view_status %}{% active request view_rounds %}">
             Pairings
@@ -97,6 +98,9 @@
             <a class="dropdown-item" href="/admin">Admin Interface</a>
           </div>
         </li>
+	<li class="nav-item">
+            <a class="nav-link" href="{{ logout }}">Logout</a>
+	</li>
       </ul>
     </div>
     {% endif %}

--- a/mittab/templates/base/_navigation.html
+++ b/mittab/templates/base/_navigation.html
@@ -99,7 +99,7 @@
           </div>
         </li>
 	<li class="nav-item">
-            <a class="nav-link" href="{{ logout }}">Logout</a>
+        <a class="nav-link" href="{{ logout }}">Logout</a>
 	</li>
       </ul>
     </div>

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -13,7 +13,8 @@ import mittab.apps.tab.pairing_views as pairing_views
 admin.autodiscover()
 
 urlpatterns = [
-    url(r"^(admin|accounts)/logout/$", views.tab_logout, name="logout"),
+    url(r"^admin/logout/$", views.tab_logout, name="admin_logout"),    
+    url(r"^accounts/logout/$", views.tab_logout, name="logout"),
     url(r"^admin/", admin.site.urls, name="admin"),
     url(r"^dynamic-media/jsi18n/$", i18n.JavaScriptCatalog.as_view(), name="js18"),
     url(r"^$", views.index, name="index"),

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -13,7 +13,7 @@ import mittab.apps.tab.pairing_views as pairing_views
 admin.autodiscover()
 
 urlpatterns = [
-    url(r"^admin/logout/$", views.tab_logout, name="admin_logout"),    
+    url(r"^admin/logout/$", views.tab_logout, name="admin_logout"),
     url(r"^accounts/logout/$", views.tab_logout, name="logout"),
     url(r"^admin/", admin.site.urls, name="admin"),
     url(r"^dynamic-media/jsi18n/$", i18n.JavaScriptCatalog.as_view(), name="js18"),


### PR DESCRIPTION
Ran into this problem at Columbia — had temporarily logged in to tab on someone's computer and there was no logout button (without going to admin)!

Edited master template, as well as disambiguated two url routes to allow url helper to function properly.

Simply a time saver.