### PR TITLE
Disable no-member linting error on failing line

### DIFF
--- a/mittab/libs/tests/helpers.py
+++ b/mittab/libs/tests/helpers.py
@@ -131,4 +131,4 @@ def generate_results(round_number,
                                             prob_forfeit=prob_forfeit,
                                             prob_ironman=prob_ironman)
         for result in results:
-            result.save()
+            result.save() # pylint: disable=E1101


### PR DESCRIPTION
Idk why this is happening. I want things to be green.