### PR TITLE
Fixes 244

### DIFF
--- a/mittab/apps/tab/debater_views.py
+++ b/mittab/apps/tab/debater_views.py
@@ -11,7 +11,7 @@ from mittab.libs.errors import *
 
 def view_debaters(request):
     #Get a list of (id,debater_name) tuples
-    c_debaters = [(debater.pk, debater.name, 0, "")
+    c_debaters = [(debater.pk, debater.display, 0, "")
                   for debater in Debater.objects.all()]
     return render(
         request, "common/list_data.html", {

--- a/mittab/apps/tab/models.py
+++ b/mittab/apps/tab/models.py
@@ -79,6 +79,16 @@ class Debater(ModelWithTiebreaker):
     )
     novice_status = models.IntegerField(choices=NOVICE_CHOICES)
 
+    @property
+    def num_teams(self):
+        return self.team_set.count()
+
+    @property
+    def display(self):
+        if self.num_teams:
+            return self.name
+        return "{} (NO TEAM)".format(self.name)
+
     def __str__(self):
         return self.name
 

--- a/mittab/apps/tab/pairing_views.py
+++ b/mittab/apps/tab/pairing_views.py
@@ -227,11 +227,10 @@ def view_round(request, round_number):
         if present_team not in paired_teams:
             excluded_teams.append(present_team)
 
-    for team in excluded_teams:
-        if not Bye.objects.filter(round_number=round_number,
-                                  bye_team=team).exists():
-            errors.append(
-                "{} is checked-in but has no round or bye".format(team))
+    excluded_teams_no_bye = [team for team in excluded_teams
+                             if not Bye.objects.filter(round_number=round_number,
+                                                       bye_team=team).exists()]
+    num_excluded = len(excluded_teams_no_bye)
 
     pairing_exists = len(round_pairing) > 0
     pairing_released = TabSettings.get("pairing_released", 0) == 1

--- a/mittab/apps/tab/views.py
+++ b/mittab/apps/tab/views.py
@@ -23,7 +23,7 @@ def index(request):
     school_list = [(school.pk, school.name) for school in School.objects.all()]
     judge_list = [(judge.pk, judge.name) for judge in Judge.objects.all()]
     team_list = [(team.pk, team.name) for team in Team.objects.all()]
-    debater_list = [(debater.pk, debater.name)
+    debater_list = [(debater.pk, debater.display)
                     for debater in Debater.objects.all()]
     room_list = [(room.pk, room.name) for room in Room.objects.all()]
 

--- a/mittab/templates/pairing/pairing_control.html
+++ b/mittab/templates/pairing/pairing_control.html
@@ -9,7 +9,7 @@
       <div class="col">
         <h3>
           Round Status for Round {{round_number}}:
-          <small class="{% if not errors %}text-success{% else %}text-danger{% endif %}">
+          <small class="{% if not errors or num_excluded == 0 %}text-success{% else %}text-danger{% endif %}">
             {% if not errors or num_excluded == 0 %} Valid {% else %} Invalid {% endif %} pairing
           </small>
         </h3>

--- a/mittab/templates/pairing/pairing_control.html
+++ b/mittab/templates/pairing/pairing_control.html
@@ -10,7 +10,7 @@
         <h3>
           Round Status for Round {{round_number}}:
           <small class="{% if not errors %}text-success{% else %}text-danger{% endif %}">
-            {% if not errors %} Valid {% else %} Invalid {% endif %} pairing
+            {% if not errors or num_excluded == 0 %} Valid {% else %} Invalid {% endif %} pairing
           </small>
         </h3>
       </div>

--- a/mittab/templates/pairing/pairing_control.html
+++ b/mittab/templates/pairing/pairing_control.html
@@ -71,6 +71,15 @@
           <div class="alert alert-danger">{{ error }}</div>
           {% endfor %}
         {% endif %}
+	{% if num_excluded > 0 %}
+	    <div class="alert alert-danger">{{ num_excluded }} teams are checked-in but have no round or bye. <button class="btn btn-small btn-link" data-toggle="collapse" data-target="#excluded_teams_no_bye">Show/Hide</button>
+		<div id="excluded_teams_no_bye" class="collapse">
+		    {% for team in excluded_teams_no_bye %}
+			{{ team.name }}<br>
+		    {% endfor %}
+		</div>
+	    </div>
+	{% endif %}
       </div>
     </div>
 


### PR DESCRIPTION
I believe this solves #244 

Two changes:

1) Adds a collapsible alert when there are teams that are checked in but aren't paired in and don't have a bye, in addition to the error containing a count.

2) On the debater list page, and the main page, a debater not on a team will have (NO TEAM) appended to the name, this is searchable on both views.