### PR TITLE
Caching results works

### DIFF
--- a/mittab/apps/tab/forms.py
+++ b/mittab/apps/tab/forms.py
@@ -8,7 +8,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 
 from mittab.apps.tab.models import *
-from mittab.libs import errors
+from mittab.libs import errors, cache_logic
 from mittab import settings
 
 
@@ -289,15 +289,17 @@ class ResultEntryForm(forms.Form):
     def save(self, _commit=True):
         cleaned_data = self.cleaned_data
         round_obj = Round.objects.get(pk=cleaned_data["round_instance"])
+
+        if not round_obj.victor == cleaned_data["winner"]:
+            cache_logic.invalidate_cache("team_rankings")
+            cache_logic.invalidate_cache("speaker_rankings")
+
         round_obj.victor = cleaned_data["winner"]
 
         with transaction.atomic():
             for debater in self.DEBATERS:
                 old_stats = RoundStats.objects.filter(round=round_obj,
                                                       debater_role=debater)
-                if old_stats.exists():
-                    old_stats.delete()
-
                 debater_obj = Debater.objects.get(
                     pk=self.deb_attr_val(debater, "debater"))
                 stats = RoundStats(
@@ -306,6 +308,17 @@ class ResultEntryForm(forms.Form):
                     speaks=self.deb_attr_val(debater, "speaks", float),
                     ranks=self.deb_attr_val(debater, "ranks", int),
                     debater_role=debater)
+
+                if old_stats.exists():
+                    for old_stat in old_stats:
+                        if (old_stat.debater != stats.debater) or \
+                           (old_stat.speaks != stats.speaks) or \
+                           (old_stat.ranks != stats.ranks) or \
+                           (old_stat.debater_role != stats.debater_role) or \
+                           (old_stat.round != stats.round):
+                            cache_logic.invalidate_cache("team_rankings")
+                            cache_logic.invalidate_cache("speaker_rankings")
+                    old_stats.delete()
                 stats.save()
             round_obj.save()
         return round_obj

--- a/mittab/apps/tab/views.py
+++ b/mittab/apps/tab/views.py
@@ -8,6 +8,7 @@ from mittab.apps.tab.forms import SchoolForm, RoomForm, UploadDataForm, ScratchF
 from mittab.apps.tab.helpers import redirect_and_flash_error, \
         redirect_and_flash_success
 from mittab.apps.tab.models import *
+from mittab.libs import cache_logic
 from mittab.libs.tab_logic import TabFlags
 from mittab.libs.data_import import import_judges, import_rooms, import_teams, \
         import_scratches
@@ -303,6 +304,17 @@ def upload_data(request):
             "room_info": room_info,
             "scratch_info": scratch_info
         })
+
+def force_cache_refresh(request):
+    key = request.GET.get("key", "")
+
+    cache_logic.invalidate_cache(key)
+
+    redirect_to = request.GET.get("next", "/")
+
+    return redirect_and_flash_success(request,
+                                      "Refreshed!",
+                                      path=redirect_to)
 
 
 @permission_required("tab.tab_settings.can_change", login_url="/403/")

--- a/mittab/libs/cache_logic.py
+++ b/mittab/libs/cache_logic.py
@@ -7,6 +7,19 @@ from django.core.cache import cache as _djcache
 CACHE_TIMEOUT = 20
 
 
+def cache_fxn_key(fxn, key, *args, **kwargs):
+    result = _djcache.get(key)
+
+    if not result:
+        result = fxn(*args, **kwargs)
+        _djcache.set(key, result)
+    return result
+
+
+def invalidate_cache(key):
+    _djcache.delete(key)
+
+
 def cache(seconds=CACHE_TIMEOUT, stampede=CACHE_TIMEOUT):
     """
     Cache the result of a function call for the specified number of seconds,

--- a/mittab/templates/tab/rank_debaters_component.html
+++ b/mittab/templates/tab/rank_debaters_component.html
@@ -1,3 +1,8 @@
+<div class="col-12">
+    <a href="{% url 'cache_refresh' %}?key=speaker_rankings&next={% url 'rank_teams_ajax' %}">
+	Force Refresh
+    </a>
+</div>
 <div class="col-6">
   <h5 class="text-center">Varsity Ranking</h5>
   <table class="table table-striped table-sm table-bordered">

--- a/mittab/templates/tab/rank_teams.html
+++ b/mittab/templates/tab/rank_teams.html
@@ -5,12 +5,11 @@
 {% block banner %} {{title}} {% endblock %}
 
 {% block content %}
-<div class="col" id="team_ranking">
-  <div class="d-flex justify-content-center p-5">
-    <div class="spinner-border" role="status">
-      <span class="sr-only">Loading...</span>
+    <div class="col" id="team_ranking">
+	<div class="d-flex justify-content-center p-5">
+	    <div class="spinner-border" role="status">
+		<span class="sr-only">Loading...</span>
+	    </div>
+	</div>
     </div>
-  </div>
-</div>
-
 {% endblock %}

--- a/mittab/templates/tab/rank_teams_component.html
+++ b/mittab/templates/tab/rank_teams_component.html
@@ -1,3 +1,8 @@
+<div class="col-12">
+    <a href="{% url 'cache_refresh' %}?key=team_rankings&next={% url 'rank_teams_ajax' %}">
+	Force Refresh
+    </a>
+</div>
 <div class="col-6">
   <h5 class="text-center">Varsity Ranking</h5>
   <table class="table table-striped table-sm table-bordered">

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -175,7 +175,10 @@ urlpatterns = [
     url(r"^import_data/$", views.upload_data, name="upload_data"),
 
     # Tournament Archive
-    url(r"^archive/download/$", views.generate_archive, name="download_archive")
+    url(r"^archive/download/$", views.generate_archive, name="download_archive"),
+
+    # Cache related
+    url(r"^cache_refresh", views.force_cache_refresh, name="cache_refresh")
 ]
 
 handler403 = "mittab.apps.tab.views.render_403"


### PR DESCRIPTION
I believe this answers #156 

Whenever the results (team or speaker) are generated, they are cached.

If a round result is changed (ie who won changed, or a speaker score / position changed) OR the force refresh button is pressed (individual to each ranking), the cache is cleared.

The makes loading the results after it has been cached pseudo-instantaneous.