### PR TITLE
Swap out dead links

### DIFF
--- a/docs/Adding-Teams,-Judges,-Rooms-and-Debaters.md
+++ b/docs/Adding-Teams,-Judges,-Rooms-and-Debaters.md
@@ -23,7 +23,7 @@ error in the format of the xlsx files, all changes generated from the file are a
 even if some were valid, so that you can simply re-upload a corrected version of the
 file
 
-You can use [these templates](https://drive.google.com/drive/folders/1w5dWkOn_p6HD24pI04xR7lzDakQMmQk3)
+You can use [these templates](https://drive.google.com/drive/folders/1ElIk0bM9uMpuewmOxb2e3-cWiLhCYv_5)
 for the teams, judges, and rooms files
 
 **NOTE:** The files _must_ be `.xlsx` files. Not `.xls`, `.csv`, or anything

--- a/mittab/templates/common/data_upload.html
+++ b/mittab/templates/common/data_upload.html
@@ -24,7 +24,7 @@
 
   <p class="text-center">
     Check out
-    <a href="https://drive.google.com/drive/folders/1w5dWkOn_p6HD24pI04xR7lzDakQMmQk3">
+    <a href="https://drive.google.com/drive/folders/1ElIk0bM9uMpuewmOxb2e3-cWiLhCYv_5">
       these templates
     </a>
     to get started and make sure to keep the header rows!


### PR DESCRIPTION
Replacement for the dead template links. Put on the APDA board Google driving, which should hopefully be more enduring than any single devs drive. Should fix failing docs test.