### PR TITLE
New Judge Options: remove judge, assign chair

### DIFF
--- a/assets/js/pairing.js
+++ b/assets/js/pairing.js
@@ -168,6 +168,62 @@ function togglePairingRelease(event) {
   });
 }
 
+function handleJudgeRemoveClick(event) {
+  event.preventDefault();
+  const roundId = $(this).attr("round-id");
+  const judgeId = $(this).attr("judge-id");
+
+  const isOutround = $(this).hasClass("outround-judge-remove");
+  const endpointPrefix = isOutround ? "outround" : "round";
+
+  function handleRemoveSuccess(response) {
+    if (response.success) {
+      window.location.reload();
+    } else {
+      alert("Failed to remove judge.");
+    }
+  }
+
+  function handleRemoveError() {
+    alert("Error removing judge.");
+  }
+
+  $.ajax({
+    url: `/${endpointPrefix}/${roundId}/remove_judge/${judgeId}/`,
+    dataType: "json",
+    success: handleRemoveSuccess,
+    error: handleRemoveError
+  });
+}
+
+function handleChairClick(event) {
+  event.preventDefault();
+  const roundId = $(this).attr("round-id");
+  const judgeId = $(this).attr("judge-id");
+
+  const isOutround = $(this).hasClass("outround-judge-chair");
+  const endpointPrefix = isOutround ? "outround" : "round";
+
+  function handleAssignSuccess(response) {
+    if (response.success) {
+      window.location.reload();
+    } else {
+      alert("Failed to assign chair.");
+    }
+  }
+
+  function handleAssignError() {
+    alert("Error assigning chair.");
+  }
+
+  $.ajax({
+    url: `/${endpointPrefix}/${roundId}/assign_chair/${judgeId}/`,
+    dataType: "json",
+    success: handleAssignSuccess,
+    error: handleAssignError
+  });
+}
+
 $(document).ready(() => {
   populateTabCards();
   $("#team_ranking").each((_, element) => {
@@ -181,4 +237,16 @@ $(document).ready(() => {
   $(".team-toggle").click(populateAlternativeTeams);
   $(".alert-link").click(alertLink);
   $(".btn.release").click(togglePairingRelease);
+
+  $(document).on(
+    "click",
+    ".judge-chair, .outround-judge-chair",
+    handleChairClick
+  );
+
+  $(document).on(
+    "click",
+    ".judge-remove, .outround-judge-remove",
+    handleJudgeRemoveClick
+  );
 });

--- a/mittab/apps/tab/outround_pairing_views.py
+++ b/mittab/apps/tab/outround_pairing_views.py
@@ -372,6 +372,7 @@ def alternative_judges(request, round_id, judge_id=None):
 
     included_judges = sorted(included_judges, key=lambda x: -x[2])
     excluded_judges = sorted(excluded_judges, key=lambda x: -x[2])
+    is_outround = True
 
     return render(request, "pairing/judge_dropdown.html", locals())
 

--- a/mittab/apps/tab/pairing_views.py
+++ b/mittab/apps/tab/pairing_views.py
@@ -667,7 +667,7 @@ def remove_judge(request, round_id, judge_id, is_outround=False):
         round_obj.judges.remove(judge)
         all_judges.remove(judge)
         if round_obj.chair == judge:
-            if len(all_judges):
+            if all_judges:
                 round_obj.chair = all_judges[0]
             else:
                 round_obj.chair = None

--- a/mittab/apps/tab/pairing_views.py
+++ b/mittab/apps/tab/pairing_views.py
@@ -2,7 +2,7 @@ import random
 import time
 import datetime
 
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponse, JsonResponse
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import permission_required
@@ -656,3 +656,36 @@ def delete_obj(obj_type):
     objs = obj_type.objects.all()
     for obj in objs:
         obj_type.delete(obj)
+
+def remove_judge(request, round_id, judge_id, is_outround=False):
+    round_id, judge_id = int(round_id), int(judge_id)
+    round_model = Outround if is_outround else Round
+    round_obj = get_object_or_404(round_model, id=round_id)
+    judge = get_object_or_404(Judge, id=judge_id)
+    if judge in round_obj.judges.all():
+        try:
+            round_obj.judges.remove(judge)
+            if round_obj.chair == judge:
+                if round_obj.judges.count() > 0:
+                    round_obj.chair = round_obj.judges.order_by("-rank").first()
+                else:
+                    round_obj.chair = None
+            round_obj.save()
+            return JsonResponse({"success": True})
+        except ValueError:
+            return redirect_and_flash_error(request, "Judge could not be removed")
+    return redirect_and_flash_error(request, "Judge not found in round")
+
+def assign_chair(request, round_id, chair_id, is_outround=False):
+    round_id, chair_id = int(round_id), int(chair_id)
+    round_model = Outround if is_outround else Round
+    round_obj = get_object_or_404(round_model, id=round_id)
+    chair = get_object_or_404(Judge, id=chair_id)
+    if chair in round_obj.judges.all():
+        try:
+            round_obj.chair = chair
+            round_obj.save()
+            return JsonResponse({"success": True})
+        except ValueError:
+            return redirect_and_flash_error(request, "Chair could not be assigned")
+    return redirect_and_flash_error(request, "Judge not found in round")

--- a/mittab/templates/pairing/judge_dropdown.html
+++ b/mittab/templates/pairing/judge_dropdown.html
@@ -1,3 +1,20 @@
+
+{% if current_judge_id %}
+<h6 class="text-center dropdown-header">Options</h6>
+
+<a href="#" class="btn btn-danger btn-sm dropdown-item {% if is_outround %}outround-judge-remove{% else %}judge-remove{% endif %}" round-id="{{round_obj.id}}" judge-id="{{current_judge_id}}">
+  Remove Judge
+</a>
+
+{% if current_judge_id != round_obj.chair.id %}
+<a href="#" class="btn btn-primary btn-sm dropdown-item {% if is_outround %}outround-judge-chair{% else %}judge-chair{% endif %}" round-id="{{round_obj.id}}" judge-id="{{current_judge_id}}">
+  Set To Chair
+</a>
+{% endif %}
+
+<div class="dropdown-divider"></div>
+{% endif %}
+
 <div class="form-group pl-2 pt-2 mb-1">
   <input id="quick-search"
         class="form-control form-control-sm" type="text" placeholder="Search...">

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -129,6 +129,10 @@ urlpatterns = [
     re_path(r"^round/(\d+)/assign_judge/(\d+)/$",
             pairing_views.assign_judge,
             name="assign_judge"),
+    path("round/<int:round_id>/remove_judge/<int:judge_id>/",
+         pairing_views.remove_judge,
+         {"is_outround": False},
+         name="remove_judge"),
     re_path(r"^pairings/assign_team/(\d+)/(gov|opp)/(\d+)/$",
             pairing_views.assign_team,
             name="assign_team"),
@@ -169,6 +173,10 @@ urlpatterns = [
             pairing_views.enter_e_ballot,
             name="enter_e_ballot"),
     path("batch_checkin/", views.batch_checkin, name="batch_checkin"),
+    path("round/<int:round_id>/assign_chair/<int:chair_id>/",
+         pairing_views.assign_chair,
+         {"is_outround": False},
+         name="assign_chair"),
 
     # Outround related
     re_path(r"break/",
@@ -192,6 +200,10 @@ urlpatterns = [
     re_path(r"^outround/(\d+)/assign_judge/(\d+)/$",
             outround_pairing_views.assign_judge,
             name="outround_assign_judge"),
+    path("outround/<int:round_id>/remove_judge/<int:judge_id>/",
+         pairing_views.remove_judge,
+         {"is_outround": True},
+         name="remove_judge"),
     re_path(r"^outround/pairings/assign_team/(\d+)/(gov|opp)/(\d+)/$",
             outround_pairing_views.assign_team,
             name="outround_assign_team"),
@@ -219,6 +231,10 @@ urlpatterns = [
     path("outround_choice/<int:outround_id>",
          outround_pairing_views.update_choice,
          name="update_choice"),
+    path("outround/<int:round_id>/assign_chair/<int:chair_id>/",
+         pairing_views.assign_chair,
+         {"is_outround": True},
+         name="assign_chair"),
 
     # Settings related
     re_path(r"^settings_form",


### PR DESCRIPTION
People keep asking for this, and the existing dropdown seemed like the easiest place to put it without interfering too much with the existing UI.

One design note:
This combines outround and inround functionality more than is ususal in the existing code base. As a result the endpoint for assign chair and remove judge for outrounds is in the pairing_views file, the outround JS is in the pairing.js file etc (mostly because the part that handles outounds is just one if statement that switches the URL or object).

Seemed preferable to repeating a lot of code, but probably goes a bit against the grain of the current design pattern, so thought it was worth flagging.