### PR TITLE
Fix Judge Assignments

### DIFF
--- a/mittab/libs/assign_judges.py
+++ b/mittab/libs/assign_judges.py
@@ -7,6 +7,11 @@ from mittab.apps.tab.models import *
 def add_judges():
     current_round_number = TabSettings.get("cur_round") - 1
 
+    # First clear any existing judge assignments
+    Round.judges.through.objects.filter(
+        round__round_number=current_round_number
+    ).delete()
+
     judges = list(
         Judge.objects.filter(
             checkin__round_number=current_round_number
@@ -16,11 +21,6 @@ def add_judges():
         )
     )
     pairings = tab_logic.sorted_pairings(current_round_number)
-
-    # First clear any existing judge assignments
-    Round.judges.through.objects.filter(
-        round__round_number=current_round_number
-    ).delete()
 
     # Try to have consistent ordering with the round display
     random.seed(1337)


### PR DESCRIPTION
Noticed some super bizarre judge assignment issues this weekend. For example:
High-ranked judge A and low-ranked judge B can both judge two rounds: one high ranked and one low ranked. Yet, assign judges gives the high ranked round to the low ranked judge.

I belive this PR solves the problem. The issue is: we fetch our judges list, with related round object **before** we delete the assignments for the current round. Logging then revealed that the current judge assignment (the one before hitting assign judges again) is being counted as a rejudge.

Simply swapping the order fixes the problem