### PR TITLE
HTML Linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,9 @@ jobs:
       - run:
           name: Lint -- JS
           command: npm run lint
+      - run:
+          name: Lint -- HTML
+          command: pipenv run djlint .
   docs:
     docker:
       - image: circleci/python:3.8

--- a/.djlintrc
+++ b/.djlintrc
@@ -1,0 +1,9 @@
+{
+    "profile" : "django",
+    "ignore" : "D018,H017,H021,H030,H031",
+    "_comments": ["D018 = Internal links should use the {% url ... %}",
+                  "H017 = Tag should be self closing",
+                  "H021 = Inline styles should be avoided]",
+                  "H030 = Consider adding a meta description",
+                  "H031 = Consider adding meta keywords"]
+}

--- a/Pipfile
+++ b/Pipfile
@@ -27,8 +27,9 @@ requests = "==2.31.0"
 selenium = "==3.141.0"
 splinter = "==0.10.0"
 Django = "==3.2.25"
-PyYAML = "==5.1.2"
+PyYAML = "*"
 sentry-sdk = {extras = ["django"], version = "*"}
+djlint = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f1782da14c9ad65a57cc68ee3504d64fd424934b05d1f3c79b84edf785160568"
+            "sha256": "9f9d6861f6326eb70cca3e28aaac76d4f089c2b956a92b93faa3bb01e6f4aa44"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -90,167 +90,43 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537",
-                "sha256:01732659ba9b5b873fc117534143e4feefecf3b2078b0a6a2e925271bb6f4cfa",
-                "sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a",
-                "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294",
-                "sha256:0907f11d019260cdc3f94fbdb23ff9125f6b5d1039b76003b5b0ac9d6a6c9d5b",
-                "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd",
-                "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601",
-                "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd",
-                "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4",
-                "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d",
-                "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2",
-                "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313",
-                "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd",
-                "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa",
-                "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8",
-                "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1",
-                "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2",
-                "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496",
-                "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d",
-                "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b",
-                "sha256:2fb9bd477fdea8684f78791a6de97a953c51831ee2981f8e4f583ff3b9d9687e",
-                "sha256:311f30128d7d333eebd7896965bfcfbd0065f1716ec92bd5638d7748eb6f936a",
-                "sha256:329ce159e82018d646c7ac45b01a430369d526569ec08516081727a20e9e4af4",
-                "sha256:345b0426edd4e18138d6528aed636de7a9ed169b4aaf9d61a8c19e39d26838ca",
-                "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78",
-                "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408",
-                "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5",
                 "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3",
-                "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f",
-                "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a",
-                "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765",
-                "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6",
-                "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146",
-                "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6",
-                "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9",
-                "sha256:619a609aa74ae43d90ed2e89bdd784765de0a25ca761b93e196d938b8fd1dbbd",
-                "sha256:6e27f48bcd0957c6d4cb9d6fa6b61d192d0b13d5ef563e5f2ae35feafc0d179c",
-                "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f",
-                "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545",
-                "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176",
-                "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770",
-                "sha256:7709f51f5f7c853f0fb938bcd3bc59cdfdc5203635ffd18bf354f6967ea0f824",
-                "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f",
-                "sha256:7974a0b5ecd505609e3b19742b60cee7aa2aa2fb3151bc917e6e2646d7667dcf",
-                "sha256:7a4f97a081603d2050bfaffdefa5b02a9ec823f8348a572e39032caa8404a487",
-                "sha256:7b1bef6280950ee6c177b326508f86cad7ad4dff12454483b51d8b7d673a2c5d",
-                "sha256:7d053096f67cd1241601111b698f5cad775f97ab25d81567d3f59219b5f1adbd",
-                "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b",
-                "sha256:807f52c1f798eef6cf26beb819eeb8819b1622ddfeef9d0977a8502d4db6d534",
-                "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f",
-                "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b",
-                "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9",
-                "sha256:89149166622f4db9b4b6a449256291dc87a99ee53151c74cbd82a53c8c2f6ccd",
-                "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125",
-                "sha256:8c60ca7339acd497a55b0ea5d506b2a2612afb2826560416f6894e8b5770d4a9",
-                "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de",
-                "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11",
-                "sha256:97f68b8d6831127e4787ad15e6757232e14e12060bec17091b85eb1486b91d8d",
-                "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35",
-                "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f",
-                "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda",
-                "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7",
-                "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a",
-                "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971",
-                "sha256:b7b2d86dd06bfc2ade3312a83a5c364c7ec2e3498f8734282c6c3d4b07b346b8",
-                "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41",
-                "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d",
-                "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f",
-                "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757",
-                "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a",
-                "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886",
-                "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77",
-                "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76",
-                "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247",
                 "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85",
-                "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb",
-                "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7",
-                "sha256:dccbe65bd2f7f7ec22c4ff99ed56faa1e9f785482b9bbd7c717e26fd723a1d1e",
-                "sha256:dd78cfcda14a1ef52584dbb008f7ac81c1328c0f58184bf9a84c49c605002da6",
-                "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037",
-                "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1",
-                "sha256:ea0d8d539afa5eb2728aa1932a988a9a7af94f18582ffae4bc10b3fbdad0626e",
-                "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807",
-                "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407",
-                "sha256:ecddf25bee22fe4fe3737a399d0d177d72bc22be6913acfab364b40bce1ba83c",
-                "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12",
-                "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3",
-                "sha256:f30bf9fd9be89ecb2360c7d94a711f00c09b976258846efe40db3d05828e8089",
-                "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd",
-                "sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e",
-                "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00",
-                "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616"
+                "sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e"
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.4.1"
         },
+        "click": {
+            "hashes": [
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.4.6"
+        },
         "coverage": {
             "hashes": [
-                "sha256:06a9a2be0b5b576c3f18f1a241f0473575c4a26021b52b2a85263a00f034d51f",
-                "sha256:06fb182e69f33f6cd1d39a6c597294cff3143554b64b9825d1dc69d18cc2fff2",
-                "sha256:0a5f9e1dbd7fbe30196578ca36f3fba75376fb99888c395c5880b355e2875f8a",
-                "sha256:0e1f928eaf5469c11e886fe0885ad2bf1ec606434e79842a879277895a50942a",
-                "sha256:171717c7cb6b453aebac9a2ef603699da237f341b38eebfee9be75d27dc38e01",
-                "sha256:1e9d683426464e4a252bf70c3498756055016f99ddaec3774bf368e76bbe02b6",
-                "sha256:201e7389591af40950a6480bd9edfa8ed04346ff80002cec1a66cac4549c1ad7",
-                "sha256:245167dd26180ab4c91d5e1496a30be4cd721a5cf2abf52974f965f10f11419f",
-                "sha256:2aee274c46590717f38ae5e4650988d1af340fe06167546cc32fe2f58ed05b02",
-                "sha256:2e07b54284e381531c87f785f613b833569c14ecacdcb85d56b25c4622c16c3c",
-                "sha256:31563e97dae5598556600466ad9beea39fb04e0229e61c12eaa206e0aa202063",
-                "sha256:33d6d3ea29d5b3a1a632b3c4e4f4ecae24ef170b0b9ee493883f2df10039959a",
-                "sha256:3d376df58cc111dc8e21e3b6e24606b5bb5dee6024f46a5abca99124b2229ef5",
-                "sha256:419bfd2caae268623dd469eff96d510a920c90928b60f2073d79f8fe2bbc5959",
-                "sha256:48c19d2159d433ccc99e729ceae7d5293fbffa0bdb94952d3579983d1c8c9d97",
-                "sha256:49969a9f7ffa086d973d91cec8d2e31080436ef0fb4a359cae927e742abfaaa6",
-                "sha256:52edc1a60c0d34afa421c9c37078817b2e67a392cab17d97283b64c5833f427f",
-                "sha256:537891ae8ce59ef63d0123f7ac9e2ae0fc8b72c7ccbe5296fec45fd68967b6c9",
-                "sha256:54b896376ab563bd38453cecb813c295cf347cf5906e8b41d340b0321a5433e5",
-                "sha256:58c2ccc2f00ecb51253cbe5d8d7122a34590fac9646a960d1430d5b15321d95f",
-                "sha256:5b7540161790b2f28143191f5f8ec02fb132660ff175b7747b95dcb77ac26562",
-                "sha256:5baa06420f837184130752b7c5ea0808762083bf3487b5038d68b012e5937dbe",
-                "sha256:5e330fc79bd7207e46c7d7fd2bb4af2963f5f635703925543a70b99574b0fea9",
-                "sha256:61b9a528fb348373c433e8966535074b802c7a5d7f23c4f421e6c6e2f1697a6f",
-                "sha256:63426706118b7f5cf6bb6c895dc215d8a418d5952544042c8a2d9fe87fcf09cb",
-                "sha256:6d040ef7c9859bb11dfeb056ff5b3872436e3b5e401817d87a31e1750b9ae2fb",
-                "sha256:6f48351d66575f535669306aa7d6d6f71bc43372473b54a832222803eb956fd1",
-                "sha256:7ee7d9d4822c8acc74a5e26c50604dff824710bc8de424904c0982e25c39c6cb",
-                "sha256:81c13a1fc7468c40f13420732805a4c38a105d89848b7c10af65a90beff25250",
-                "sha256:8d13c64ee2d33eccf7437961b6ea7ad8673e2be040b4f7fd4fd4d4d28d9ccb1e",
-                "sha256:8de8bb0e5ad103888d65abef8bca41ab93721647590a3f740100cd65c3b00511",
-                "sha256:8fa03bce9bfbeeef9f3b160a8bed39a221d82308b4152b27d82d8daa7041fee5",
                 "sha256:924d94291ca674905fe9481f12294eb11f2d3d3fd1adb20314ba89e94f44ed59",
-                "sha256:975d70ab7e3c80a3fe86001d8751f6778905ec723f5b110aed1e450da9d4b7f2",
-                "sha256:976b9c42fb2a43ebf304fa7d4a310e5f16cc99992f33eced91ef6f908bd8f33d",
-                "sha256:9e31cb64d7de6b6f09702bb27c02d1904b3aebfca610c12772452c4e6c21a0d3",
-                "sha256:a342242fe22407f3c17f4b499276a02b01e80f861f1682ad1d95b04018e0c0d4",
-                "sha256:a3d33a6b3eae87ceaefa91ffdc130b5e8536182cd6dfdbfc1aa56b46ff8c86de",
-                "sha256:a895fcc7b15c3fc72beb43cdcbdf0ddb7d2ebc959edac9cef390b0d14f39f8a9",
-                "sha256:afb17f84d56068a7c29f5fa37bfd38d5aba69e3304af08ee94da8ed5b0865833",
-                "sha256:b1c546aca0ca4d028901d825015dc8e4d56aac4b541877690eb76490f1dc8ed0",
-                "sha256:b29019c76039dc3c0fd815c41392a044ce555d9bcdd38b0fb60fb4cd8e475ba9",
-                "sha256:b46517c02ccd08092f4fa99f24c3b83d8f92f739b4657b0f146246a0ca6a831d",
-                "sha256:b7aa5f8a41217360e600da646004f878250a0d6738bcdc11a0a39928d7dc2050",
-                "sha256:b7b4c971f05e6ae490fef852c218b0e79d4e52f79ef0c8475566584a8fb3e01d",
-                "sha256:ba90a9563ba44a72fda2e85302c3abc71c5589cea608ca16c22b9804262aaeb6",
-                "sha256:cb017fd1b2603ef59e374ba2063f593abe0fc45f2ad9abdde5b4d83bd922a353",
-                "sha256:d22656368f0e6189e24722214ed8d66b8022db19d182927b9a248a2a8a2f67eb",
-                "sha256:d2c2db7fd82e9b72937969bceac4d6ca89660db0a0967614ce2481e81a0b771e",
-                "sha256:d39b5b4f2a66ccae8b7263ac3c8170994b65266797fb96cbbfd3fb5b23921db8",
-                "sha256:d62a5c7dad11015c66fbb9d881bc4caa5b12f16292f857842d9d1871595f4495",
-                "sha256:e7d9405291c6928619403db1d10bd07888888ec1abcbd9748fdaa971d7d661b2",
-                "sha256:e84606b74eb7de6ff581a7915e2dab7a28a0517fbe1c9239eb227e1354064dcd",
-                "sha256:eb393e5ebc85245347950143969b241d08b52b88a3dc39479822e073a1a8eb27",
-                "sha256:ebba1cd308ef115925421d3e6a586e655ca5a77b5bf41e02eb0e4562a111f2d1",
-                "sha256:ee57190f24fba796e36bb6d3aa8a8783c643d8fa9760c89f7a98ab5455fbf818",
-                "sha256:f2f67fe12b22cd130d34d0ef79206061bfb5eda52feb6ce0dba0644e20a03cf4",
-                "sha256:f6951407391b639504e3b3be51b7ba5f3528adbf1a8ac3302b687ecababf929e",
-                "sha256:f75f7168ab25dd93110c8a8117a22450c19976afbc44234cbf71481094c1b850",
-                "sha256:fdec9e8cbf13a5bf63290fc6013d216a4c7232efb51548594ca3631a7f13c3a3"
+                "sha256:e84606b74eb7de6ff581a7915e2dab7a28a0517fbe1c9239eb227e1354064dcd"
             ],
             "markers": "python_version >= '3.7'",
             "version": "==7.2.7"
+        },
+        "cssbeautifier": {
+            "hashes": [
+                "sha256:78c84d5e5378df7d08622bbd0477a1abdbd209680e95480bf22f12d5701efc98",
+                "sha256:9bb08dc3f64c101a01677f128acf01905914cf406baf87434dcde05b74c0acf5"
+            ],
+            "version": "==1.15.4"
         },
         "django": {
             "hashes": [
@@ -286,6 +162,22 @@
             "index": "pypi",
             "version": "==0.6.0"
         },
+        "djlint": {
+            "hashes": [
+                "sha256:0817bbc69df234a4a6208685c6ff2d521f64a330eb1f7c0a052025233a21971c",
+                "sha256:bed6fa1c97aa88d4be23d9234de0c5eba71a908871d34eb9704f1df286a80335"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.7.2' and python_full_version < '4.0.0'",
+            "version": "==1.19.16"
+        },
+        "editorconfig": {
+            "hashes": [
+                "sha256:8739052279699840065d3a9f5c125d7d5a98daeefe53b0e5274261d77cb49aa2",
+                "sha256:fe491719c5f65959ec00b167d07740e7ffec9a3f362038c72b289330b9991dfc"
+            ],
+            "version": "==0.17.0"
+        },
         "gprof2dot": {
             "hashes": [
                 "sha256:45b4d298bd36608fccf9511c3fd88a773f7a1abc04d6cd39445b11ba43133ec5",
@@ -309,6 +201,22 @@
             ],
             "index": "pypi",
             "version": "==2.1.0"
+        },
+        "html-tag-names": {
+            "hashes": [
+                "sha256:04924aca48770f36b5a41c27e4d917062507be05118acb0ba869c97389084297",
+                "sha256:eeb69ef21078486b615241f0393a72b41352c5219ee648e7c61f5632d26f0420"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==0.1.2"
+        },
+        "html-void-elements": {
+            "hashes": [
+                "sha256:784cf39db03cdeb017320d9301009f8f3480f9d7b254d0974272e80e0cb5e0d2",
+                "sha256:931b88f84cd606fee0b582c28fcd00e41d7149421fb673e1e1abd2f0c4f231f0"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==0.1.0"
         },
         "idna": {
             "hashes": [
@@ -342,44 +250,17 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.0.1"
         },
+        "jsbeautifier": {
+            "hashes": [
+                "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592",
+                "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528"
+            ],
+            "version": "==1.15.4"
+        },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382",
-                "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82",
-                "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9",
-                "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494",
-                "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46",
-                "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30",
-                "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63",
-                "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4",
                 "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae",
-                "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be",
-                "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701",
-                "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd",
-                "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006",
-                "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a",
-                "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586",
-                "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8",
-                "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821",
-                "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07",
-                "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b",
-                "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171",
-                "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b",
-                "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2",
-                "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7",
-                "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4",
-                "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8",
-                "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e",
-                "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f",
-                "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda",
-                "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4",
-                "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e",
-                "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671",
-                "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11",
-                "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455",
-                "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734",
-                "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb",
-                "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
+                "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2"
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.9.0"
@@ -409,12 +290,18 @@
         },
         "mysqlclient": {
             "hashes": [
-                "sha256:79a498ddda955e488f80c82a6392bf6e07c323d48db236033f33825665d8ba5c",
-                "sha256:8c3b61d89f7daaeab6aad6bf4c4bc3ef30bec1a8169f94dc59aea87ba2fabf80",
                 "sha256:9c737cc55a5dc8dd3583a942d5a9b21be58d16f00f5fefca4e575e7d9682e98c"
             ],
             "index": "pypi",
             "version": "==1.4.4"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20",
+                "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.11.2"
         },
         "pluggy": {
             "hashes": [
@@ -526,21 +413,69 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
-                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
-                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
-                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
-                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
-                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
-                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
-                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
-                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
-                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
-                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
-                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
-                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+                "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
+                "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df",
+                "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
+                "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
+                "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
+                "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595",
+                "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
+                "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
+                "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290",
+                "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9",
+                "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6",
+                "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
+                "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
+                "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
+                "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
+                "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
+                "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
+                "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0",
+                "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
+                "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
+                "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28",
+                "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
+                "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
+                "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+                "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef",
+                "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
+                "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd",
+                "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3",
+                "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
+                "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515",
+                "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c",
+                "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
+                "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924",
+                "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34",
+                "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
+                "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
+                "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54",
+                "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
+                "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
+                "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
+                "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
+                "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585",
+                "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d",
+                "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
-            "version": "==5.1.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==6.0.1"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:1ddf14031a3882f684b8642cb74eea3af93a2be68893901b2b387c5fd92a03ec",
+                "sha256:a3a98921da9a1bf8457aeee6a551948a83601689e5ecdd736894ea9bbec77e83",
+                "sha256:ce6910b56b700bea7be82c54ddf2e0ed792a577dfaa4a76b9af07d550af435c6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.10.31"
         },
         "requests": {
             "hashes": [
@@ -604,8 +539,7 @@
         },
         "splinter": {
             "hashes": [
-                "sha256:2d9f370536e6c1607824f5538e0bff9808bc02f086b07622b3790424dd3daff4",
-                "sha256:5d9913bddb6030979c18d6801578813b02bbf8a03b43fb057f093228ed876d62"
+                "sha256:2d9f370536e6c1607824f5538e0bff9808bc02f086b07622b3790424dd3daff4"
             ],
             "index": "pypi",
             "version": "==0.10.0"
@@ -625,6 +559,14 @@
             ],
             "markers": "python_version < '3.11'",
             "version": "==2.0.1"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2",
+                "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.67.1"
         },
         "typed-ast": {
             "hashes": [
@@ -691,76 +633,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc",
-                "sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81",
-                "sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09",
-                "sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e",
-                "sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca",
-                "sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0",
-                "sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb",
-                "sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487",
-                "sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40",
-                "sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c",
-                "sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060",
-                "sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202",
-                "sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41",
-                "sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9",
-                "sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b",
-                "sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664",
                 "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d",
-                "sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362",
-                "sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00",
-                "sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc",
                 "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1",
-                "sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267",
-                "sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956",
-                "sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966",
-                "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1",
-                "sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228",
-                "sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72",
-                "sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d",
-                "sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292",
-                "sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0",
-                "sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0",
-                "sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36",
-                "sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c",
-                "sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5",
-                "sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f",
-                "sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73",
-                "sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b",
-                "sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2",
-                "sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593",
-                "sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39",
-                "sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389",
-                "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf",
-                "sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf",
-                "sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89",
-                "sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c",
-                "sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c",
-                "sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f",
-                "sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440",
-                "sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465",
-                "sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136",
-                "sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b",
-                "sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8",
-                "sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3",
-                "sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8",
-                "sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6",
-                "sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e",
-                "sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f",
-                "sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c",
-                "sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e",
-                "sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8",
-                "sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2",
-                "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020",
-                "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35",
-                "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d",
-                "sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3",
-                "sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537",
-                "sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809",
-                "sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d",
-                "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a",
-                "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"
+                "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf"
             ],
             "markers": "python_version < '3.11'",
             "version": "==1.16.0"

--- a/mittab/templates/admin/base_site.html
+++ b/mittab/templates/admin/base_site.html
@@ -1,10 +1,13 @@
 {% extends "admin/base.html" %}
 {% load i18n %}
-
-{% block title %}{{ title }} | {% trans 'MIT-TAB site admin' %}{% endblock %}
-
+{% block title %}
+    {{ title }} | {% trans "MIT-TAB site admin" %}
+{% endblock title %}
 {% block branding %}
-<h1 id="site-name">{% trans 'MIT-TAB site administration' %}</h1>
-{% endblock %}
-
-{% block nav-global %}<div style="padding: 0 10px 10px;font-size: 18px;"><a  href="/">Go Back to Main Homepage</a></div>{% endblock %}
+    <h1 id="site-name">{% trans "MIT-TAB site administration" %}</h1>
+{% endblock branding %}
+{% block nav-global %}
+    <div style="padding: 0 10px 10px;font-size: 18px;">
+        <a href="/">Go Back to Main Homepage</a>
+    </div>
+{% endblock nav-global %}

--- a/mittab/templates/ballots/_form.html
+++ b/mittab/templates/ballots/_form.html
@@ -1,145 +1,94 @@
 {% load bootstrap4 %}
-
 {% if form.errors %}
-  <div class="alert alert-danger">
-    Please correct the error{{ form.errors|pluralize }} below.
-
-    {% bootstrap_form_errors form type='non_fields' %}
-  </div>
+    <div class="alert alert-danger">
+        Please correct the error{{ form.errors|pluralize }} below.
+        {% bootstrap_form_errors form type='non_fields' %}
+    </div>
 {% endif %}
-
 {{ form.media }}
-
-{% for hidden in form.hidden_fields %}
-  {{ hidden }}
-{% endfor %}
-
+{% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
 <div class="row">
-  <div class="form-group col-md-6">
-    {% bootstrap_field form.winner %}
-    <div class="mt-2">
-      <div class="hidden winner" data-option=0>Please select a winner</div>
-      <div class="hidden winner alert alert-info" data-option=1>
-          The Government team has won.  Enter speaks and ranks
-          normally.
-      </div>
-      <div class="hidden winner alert alert-info" data-option=2>
-          The Opposition team has won. Enter speaks and ranks
-          normally
-      </div>
-      <div class="hidden winner alert alert-info" data-option=3>
-          The Government team has won via forfeit. Enter speaks of
-          zero and arbitrary ranks for all debaters. The winning team
-          will receive average speaks and ranks for this round. 
-          The losing team will receive speaks of zero and ranks of 7,
-          although you can give them non zero speaks if you wish.
-      </div>
-      <div class="hidden winner alert alert-info" data-option=4>
-          The Opposition team has won via forfeit. Enter speaks of
-          zero and arbitrary ranks for all debaters. The winning team
-          will receive average speaks and ranks for this round. 
-          The losing team will receive speaks of zero and ranks of 7,
-          although you can give them non zero speaks if you wish.
-      </div>
-      <div class="hidden winner alert alert-info" data-option=5>
-          Everyone lost this round (didn't show up?). Enter speaks of
-          zero and arbitrary ranks. Both teams will receive speaks of
-          zero and ranks of 7, although you can give them non zero
-          speaks if you wish.  No averaging will occur, however.
-      </div>
-      <div class="hidden winner alert alert-info" data-option=6>
-          Everyone won this round (judge didn't show up). Enter speaks
-          of zero and arbitrary ranks. Both teams will receive average
-          speaks and ranks for this round. Do <b>not</b> give speaks
-          greater than zero to either team.
-      </div>
+    <div class="form-group col-md-6">
+        {% bootstrap_field form.winner %}
+        <div class="mt-2">
+            <div class="hidden winner" data-option=0>Please select a winner</div>
+            <div class="hidden winner alert alert-info" data-option=1>
+                The Government team has won.  Enter speaks and ranks
+                normally.
+            </div>
+            <div class="hidden winner alert alert-info" data-option=2>
+                The Opposition team has won. Enter speaks and ranks
+                normally
+            </div>
+            <div class="hidden winner alert alert-info" data-option=3>
+                The Government team has won via forfeit. Enter speaks of
+                zero and arbitrary ranks for all debaters. The winning team
+                will receive average speaks and ranks for this round.
+                The losing team will receive speaks of zero and ranks of 7,
+                although you can give them non zero speaks if you wish.
+            </div>
+            <div class="hidden winner alert alert-info" data-option=4>
+                The Opposition team has won via forfeit. Enter speaks of
+                zero and arbitrary ranks for all debaters. The winning team
+                will receive average speaks and ranks for this round.
+                The losing team will receive speaks of zero and ranks of 7,
+                although you can give them non zero speaks if you wish.
+            </div>
+            <div class="hidden winner alert alert-info" data-option=5>
+                Everyone lost this round (didn't show up?). Enter speaks of
+                zero and arbitrary ranks. Both teams will receive speaks of
+                zero and ranks of 7, although you can give them non zero
+                speaks if you wish.  No averaging will occur, however.
+            </div>
+            <div class="hidden winner alert alert-info" data-option=6>
+                Everyone won this round (judge didn't show up). Enter speaks
+                of zero and arbitrary ranks. Both teams will receive average
+                speaks and ranks for this round. Do <b>not</b> give speaks
+                greater than zero to either team.
+            </div>
+        </div>
     </div>
-  </div>
-  {% if form.ballot_code %}
-  <div class="form-group col-md-6">
-    {% bootstrap_field form.ballot_code %}
-  </div>
-  {% endif %}
+    {% if form.ballot_code %}
+        <div class="form-group col-md-6">{% bootstrap_field form.ballot_code %}</div>
+    {% endif %}
 </div>
-
-
 <div class="row">
-<div class="col-md-6">
-  <div class="card">
-    <div class="card-header">
-      Government: {{ gov_team.display }}
-    </div>
-
-    <div class="card-body">
-      <div class="gov">
-        <div class="pm row pb-1 border-bottom">
-          <div class="col-12 form-group">
-            {% bootstrap_field form.pm_debater %}
-          </div>
-
-          <div class="speaks col-md-6 form-group">
-            {% bootstrap_field form.pm_speaks %}
-          </div>
-
-          <div class="ranks col-md-6 form-group">
-            {% bootstrap_field form.pm_ranks %}
-          </div>
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">Government: {{ gov_team.display }}</div>
+            <div class="card-body">
+                <div class="gov">
+                    <div class="pm row pb-1 border-bottom">
+                        <div class="col-12 form-group">{% bootstrap_field form.pm_debater %}</div>
+                        <div class="speaks col-md-6 form-group">{% bootstrap_field form.pm_speaks %}</div>
+                        <div class="ranks col-md-6 form-group">{% bootstrap_field form.pm_ranks %}</div>
+                    </div>
+                    <div class="mg row pt-3">
+                        <div class="col-12 form-group">{% bootstrap_field form.mg_debater %}</div>
+                        <div class="speaks col-md-6 form-group">{% bootstrap_field form.mg_speaks %}</div>
+                        <div class="ranks col-md-6 form-group">{% bootstrap_field form.mg_ranks %}</div>
+                    </div>
+                </div>
+            </div>
         </div>
-
-        <div class="mg row pt-3">
-          <div class="col-12 form-group">
-            {% bootstrap_field form.mg_debater %}
-          </div>
-
-          <div class="speaks col-md-6 form-group">
-            {% bootstrap_field form.mg_speaks %}
-          </div>
-
-          <div class="ranks col-md-6 form-group">
-            {% bootstrap_field form.mg_ranks %}
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
-
-<div class="col-md-6">
-  <div class="card">
-    <div class="card-header">
-      Opposition: {{opp_team.display}}
-    </div>
-    <div class="card-body">
-      <div class="opp">
-        <div class="lo row pb-1 border-bottom">
-          <div class="col-12 form-group">
-            {% bootstrap_field form.lo_debater %}
-          </div>
-
-          <div class="speaks col-md-6 form-group">
-            {% bootstrap_field form.lo_speaks %}
-          </div>
-
-          <div class="ranks col-md-6 form-group">
-            {% bootstrap_field form.lo_ranks %}
-          </div>
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">Opposition: {{ opp_team.display }}</div>
+            <div class="card-body">
+                <div class="opp">
+                    <div class="lo row pb-1 border-bottom">
+                        <div class="col-12 form-group">{% bootstrap_field form.lo_debater %}</div>
+                        <div class="speaks col-md-6 form-group">{% bootstrap_field form.lo_speaks %}</div>
+                        <div class="ranks col-md-6 form-group">{% bootstrap_field form.lo_ranks %}</div>
+                    </div>
+                    <div class="mo row pt-3">
+                        <div class="col-12 form-group">{% bootstrap_field form.mo_debater %}</div>
+                        <div class="speaks col-md-6 form-group">{% bootstrap_field form.mo_speaks %}</div>
+                        <div class="ranks col-md-6 form-group">{% bootstrap_field form.mo_ranks %}</div>
+                    </div>
+                </div>
+            </div>
         </div>
-
-        <div class="mo row pt-3">
-          <div class="col-12 form-group">
-            {% bootstrap_field form.mo_debater %}
-          </div>
-
-          <div class="speaks col-md-6 form-group">
-            {% bootstrap_field form.mo_speaks %}
-          </div>
-
-          <div class="ranks col-md-6 form-group">
-            {% bootstrap_field form.mo_ranks %}
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
 </div>

--- a/mittab/templates/ballots/missing_ballots.html
+++ b/mittab/templates/ballots/missing_ballots.html
@@ -1,36 +1,34 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}Missing Ballots{% endblock %}
-
+{% block title %}
+    Missing Ballots
+{% endblock title %}
 {% block content %}
-
-<div class="col-2"></div>
-<div class="col-8">
-{% if pairing_exists %}
-  {% if rounds %}
-    <h2 class="text-center">Missing Ballots</h2>
-    <p class="lead text-center">This list will refresh every 30 seconds</p>
-    <ul class="missing-rounds list-group list-group-flush">
-    <h3 class="text-center">Missing: {{ rounds|length }}</h1>
-    {% for r in rounds %}
-    <li class="missing-round-item list-group-item text-lg">
-      <h5>
-        {{r.chair.name}}
-        <small class="text-muted">Round between {{r.gov_team.display}} and {{r.opp_team.display}}</small>
-      </h5>
-    </li>
-    {% endfor %}
-    </ul>
-
-    <script>
-      window.setTimeout(function() { location.reload(true) }, 30000);
-    </script>
-  {% else %}
-    <h3 class="text-center">All ballots entered!</h3>
-  {% endif %}
-{% else %}
-  <h3 class="text-center">Pairing not released</h3>
-{% endif %}
-<div class="col-2"></div>
-{% endblock %}
+    <div class="col-2"></div>
+    <div class="col-8">
+        {% if pairing_exists %}
+            {% if rounds %}
+                <h2 class="text-center">Missing Ballots</h2>
+                <p class="lead text-center">This list will refresh every 30 seconds</p>
+                <ul class="missing-rounds list-group list-group-flush">
+                    <h3 class="text-center">
+                        Missing: {{ rounds|length }}
+                    </h3>
+                    {% for r in rounds %}
+                        <li class="missing-round-item list-group-item text-lg">
+                            <h5>
+                                {{ r.chair.name }}
+                                <small class="text-muted">Round between {{ r.gov_team.display }} and {{ r.opp_team.display }}</small>
+                            </h5>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <script>window.setTimeout(function() { location.reload(true) }, 30000);</script>
+            {% else %}
+                <h3 class="text-center">All ballots entered!</h3>
+            {% endif %}
+        {% else %}
+            <h3 class="text-center">Pairing not released</h3>
+        {% endif %}
+        <div class="col-2"></div>
+    {% endblock content %}
 </div>

--- a/mittab/templates/ballots/round_entry.html
+++ b/mittab/templates/ballots/round_entry.html
@@ -1,24 +1,26 @@
 {% extends "base/__wide.html" %}
 {% load tags %}
-
-{% block title %}Data Entry{% endblock %}
-
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    Data Entry
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
-
-<div class="col">
-  <div class="container-fluid">
-    <form action="{{ action }}" method="post" class="ballot-form single" enctype="multipart/form-data">{% csrf_token %}
-    {% round_form form gov_team opp_team %}
-
-    <div class="row">
-      <div class="col mt-2">
-        <input class="btn btn-primary" type="submit" value="Save"/>
-      </div>
+    <div class="col">
+        <div class="container-fluid">
+            <form action="{{ action }}"
+                  method="post"
+                  class="ballot-form single"
+                  enctype="multipart/form-data">
+                {% csrf_token %}
+                {% round_form form gov_team opp_team %}
+                <div class="row">
+                    <div class="col mt-2">
+                        <input class="btn btn-primary" type="submit" value="Save" />
+                    </div>
+                </div>
+            </form>
+        </div>
     </div>
-    </form>
-  </div>
-</div>
-
-{% endblock %}
+{% endblock content %}

--- a/mittab/templates/ballots/round_entry_multiple.html
+++ b/mittab/templates/ballots/round_entry_multiple.html
@@ -1,42 +1,45 @@
 {% extends "base/__wide.html" %}
 {% load tags %}
-
-{% block title %}Data Entry{% endblock %}
-
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    Data Entry
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
-<div class="col">
-  <div class="container-fluid">
-    <form action="" method="post" class="ballot-form" enctype="multipart/form-data">
-
-
-      <div class="row">
-        <div class="col">
-          <div class="alert alert-info">
-            <div class="form-group">
-              <label class="checkbox" for="discard_minority">
-                Check this box if you would like to discard any minority ballots.
-                This will ensure that you cannot have low point wins.
-              </label>
-              <input type="checkbox" id="discard_minority" class="form-control" name="discard_minority" value="minority" checked/>
-            </div>
-          </div>
+    <div class="col">
+        <div class="container-fluid">
+            <form action=""
+                  method="post"
+                  class="ballot-form"
+                  enctype="multipart/form-data">
+                <div class="row">
+                    <div class="col">
+                        <div class="alert alert-info">
+                            <div class="form-group">
+                                <label class="checkbox" for="discard_minority">
+                                    Check this box if you would like to discard any minority ballots.
+                                    This will ensure that you cannot have low point wins.
+                                </label>
+                                <input type="checkbox"
+                                       id="discard_minority"
+                                       class="form-control"
+                                       name="discard_minority"
+                                       value="minority"
+                                       checked />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {% for form in forms %}
+                    <div class="pb-4 mb-4 border-bottom">{% round_form form gov_team opp_team %}</div>
+                {% endfor %}
+                <div class="row">
+                    <div class="col">
+                        <input class="btn btn-primary" type="submit" value="Save" />
+                    </div>
+                </div>
+            </form>
         </div>
-      </div>
-
-      {% for form in forms %}
-      <div class="pb-4 mb-4 border-bottom">
-        {% round_form form gov_team opp_team %}
-      </div>
-      {% endfor %}
-
-      <div class="row">
-        <div class="col">
-          <input class="btn btn-primary" type="submit" value="Save"/>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
-{% endblock %}
+    </div>
+{% endblock content %}

--- a/mittab/templates/base/__normal.html
+++ b/mittab/templates/base/__normal.html
@@ -1,70 +1,69 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
 <html lang="en">
-<head>
-    {% load render_bundle from webpack_loader %}
-    {% render_bundle 'main' %}
-
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script type="text/javascript" src="/static/admin/js/jquery.init.js"></script>
-    <script type="text/javascript" src="/static/admin/js/admin/RelatedObjectLookups.js"></script>
-    <link rel="stylesheet"
-        href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
-        integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay"
-        crossorigin="anonymous">
-    <title>{% block title %}{% endblock %}</title>
-</head>
-<body>
-  {% with smaller_width=True %}
-  {% include "base/_navigation.html" %}
-  {% endwith %}
-
-  <div class="container-fluid text-left">
-
-    <div id="container-main" class="container p-3 rounded shadow-sm">
-      <div class="row">
-        <div class="col">
-          {% if messages %}
-            {% for message in messages %}
-            <div class="alert {% if message.tags %}alert-{% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}danger{% else %}{{ message.tags }}{% endif %}{% endif %}">
-              {{ message }}
+    <head>
+        {% load render_bundle from webpack_loader %}
+        {% render_bundle 'main' %}
+        <script type="text/javascript"
+                src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+        <script type="text/javascript" src="/static/admin/js/jquery.init.js"></script>
+        <script type="text/javascript"
+                src="/static/admin/js/admin/RelatedObjectLookups.js"></script>
+        <link rel="stylesheet"
+              href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
+              integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay"
+              crossorigin="anonymous">
+        <title>
+            {% block title %}
+            {% endblock title %}
+        </title>
+    </head>
+    <body>
+        {% with smaller_width=True %}
+            {% include "base/_navigation.html" %}
+        {% endwith %}
+        <div class="container-fluid text-left">
+            <div id="container-main" class="container p-3 rounded shadow-sm">
+                <div class="row">
+                    <div class="col">
+                        {% if messages %}
+                            {% for message in messages %}
+                                <div class="alert {% if message.tags %}alert-{% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}danger{% else %}{{ message.tags }}{% endif %}{% endif %}">
+                                    {{ message }}
+                                </div>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col">
+                        <h3>
+                            {% block banner %}
+                            {% endblock banner %}
+                        </h3>
+                    </div>
+                </div>
+                <div class="row mt-2">
+                    {% block content %}
+                    {% endblock content %}
+                </div>
+                {% if links %}
+                    <div class="row mt-2 mb-2">
+                        <div class="col">
+                            <hr />
+                            <div class="btn-group">
+                                {% for link,text in links %}<a class="btn btn-sm btn-secondary" href="{{ link }}">{{ text }}</a>{% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
-            {% endfor %}
-          {% endif %}
+            <div class="row-fluid mt-3 text-center footer">
+                <small>
+                    Need help? Check out <a href="https://mit-tab.readthedocs.io">the documentation.</a>
+                    <br />
+                    MIT-TAB, published under the MIT License by Joey Lynch and Julia Boortz
+                </small>
+            </div>
         </div>
-      </div>
-
-      <div class="row">
-        <div class="col">
-          <h3>{% block banner %}{% endblock %}</h3>
-        </div>
-      </div>
-
-      <div class="row mt-2">
-        {% block content %}{% endblock %}
-      </div>
-
-      {% if links %}
-      <div class="row mt-2 mb-2">
-        <div class="col">
-          <hr/>
-          <div class="btn-group">
-            {% for link,text in links %}
-              <a class="btn btn-sm btn-secondary" href="{{link}}">{{text}}</a>
-            {% endfor %}
-          </div>
-        </div>
-      </div>
-      {%endif%}
-
-    </div>
-
-    <div class="row-fluid mt-3 text-center footer">
-      <small>
-        Need help? Check out <a href="https://mit-tab.readthedocs.io">the documentation.</a>
-        <br/>
-        MIT-TAB, published under the MIT License by Joey Lynch and Julia Boortz
-      </small>
-    </div>
-  </div>
-</body>
+    </body>
 </html>

--- a/mittab/templates/base/__wide.html
+++ b/mittab/templates/base/__wide.html
@@ -1,67 +1,67 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
 <html lang="en">
-<head>
-    {% load render_bundle from webpack_loader %}
-    {% render_bundle 'main' %}
-
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script type="text/javascript" src="/static/admin/js/jquery.init.js"></script>
-    <script type="text/javascript" src="/static/admin/js/admin/RelatedObjectLookups.js"></script>
-    <link rel="stylesheet"
-        href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
-        integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay"
-        crossorigin="anonymous">
-    <title>{% block title %}{% endblock %}</title>
-</head>
-<body>
-  {% include "base/_navigation.html" %}
-
-  <div class="container-fluid text-left">
-
-    <div id="container-main" class="container p-3 w-95 rounded shadow-sm">
-      <div class="row">
-        <div class="col">
-          {% if messages %}
-            {% for message in messages %}
-            <div class="alert {% if message.tags %}alert-{% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}danger{% else %}{{ message.tags }}{% endif %}{% endif %}">
-              {{ message }}
+    <head>
+        {% load render_bundle from webpack_loader %}
+        {% render_bundle 'main' %}
+        <script type="text/javascript"
+                src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+        <script type="text/javascript" src="/static/admin/js/jquery.init.js"></script>
+        <script type="text/javascript"
+                src="/static/admin/js/admin/RelatedObjectLookups.js"></script>
+        <link rel="stylesheet"
+              href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
+              integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay"
+              crossorigin="anonymous">
+        <title>
+            {% block title %}
+            {% endblock title %}
+        </title>
+    </head>
+    <body>
+        {% include "base/_navigation.html" %}
+        <div class="container-fluid text-left">
+            <div id="container-main" class="container p-3 w-95 rounded shadow-sm">
+                <div class="row">
+                    <div class="col">
+                        {% if messages %}
+                            {% for message in messages %}
+                                <div class="alert {% if message.tags %}alert-{% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}danger{% else %}{{ message.tags }}{% endif %}{% endif %}">
+                                    {{ message }}
+                                </div>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col">
+                        <h3>
+                            {% block banner %}
+                            {% endblock banner %}
+                        </h3>
+                    </div>
+                </div>
+                <div class="row mt-2">
+                    {% block content %}
+                    {% endblock content %}
+                </div>
+                {% if links %}
+                    <div class="row mt-2 mb-2">
+                        <div class="col">
+                            <hr />
+                            <div class="btn-group">
+                                {% for link,text in links %}<a class="btn btn-sm btn-secondary" href="{{ link }}">{{ text }}</a>{% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
-            {% endfor %}
-          {% endif %}
+            <div class="row-fluid mt-3 text-center footer">
+                <small>
+                    Need help? Check out <a href="https://mit-tab.readthedocs.io">the documentation.</a>
+                    <br />
+                    MIT-TAB, published under the MIT License by Joey Lynch and Julia Boortz
+                </small>
+            </div>
         </div>
-      </div>
-
-      <div class="row">
-        <div class="col">
-          <h3>{% block banner %}{% endblock %}</h3>
-        </div>
-      </div>
-
-      <div class="row mt-2">
-        {% block content %}{% endblock %}
-      </div>
-
-      {% if links %}
-      <div class="row mt-2 mb-2">
-        <div class="col">
-          <hr/>
-          <div class="btn-group">
-            {% for link,text in links %}
-              <a class="btn btn-sm btn-secondary" href="{{link}}">{{text}}</a>
-            {% endfor %}
-          </div>
-        </div>
-      </div>
-      {%endif%}
-    </div>
-
-    <div class="row-fluid mt-3 text-center footer">
-      <small>
-        Need help? Check out <a href="https://mit-tab.readthedocs.io">the documentation.</a>
-        <br/>
-        MIT-TAB, published under the MIT License by Joey Lynch and Julia Boortz
-      </small>
-    </div>
-  </div>
-</body>
+    </body>
 </html>

--- a/mittab/templates/base/_navigation.html
+++ b/mittab/templates/base/_navigation.html
@@ -1,28 +1,21 @@
 {% load tags %}
-
 {% url "index" as home %}
 {% url "logout" as logout %}
-
 {% url "enter_school" as enter_school %}
 {% url "view_schools" as view_schools %}
-
 {% url "enter_room" as enter_room %}
 {% url "view_rooms" as view_rooms %}
-
 {% url "enter_judge" as enter_judge %}
-{% url "view_judges" as view_judges%}
+{% url "view_judges" as view_judges %}
 {% url "batch_checkin" as batch_checkin %}
-
 {% url "enter_team" as enter_team %}
-{% url "view_teams" as view_teams%}
+{% url "view_teams" as view_teams %}
 {% url "rank_teams_ajax" as rank_teams %}
 {% url "all_tab_cards" as tab_cards %}
 {% url "download_archive" as download_archive %}
-
 {% url "enter_debater" as enter_debater %}
 {% url "view_debaters" as view_debaters %}
 {% url "rank_debaters_ajax" as rank_debaters %}
-
 {% url "view_status" as view_status %}
 {% url "view_rounds" as view_rounds %}
 {% url "pair_round" as pair_round %}
@@ -34,80 +27,99 @@
 {% url "add_scratch" as add_scratch %}
 {% url "settings_form" as settings_form %}
 {% url "outround_pairing_view_default" as outround_pairings %}
-
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm">
-  <div class="container {% if not smaller_width %} w-95{% endif %}">
-    <a class="navbar-brand text-extra-bold{% if not user.is_authenticated %} no-nav{% endif %}" href="{{ home }}">MIT-TAB</a>
-
-    {% if user.is_authenticated %}
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav mr-auto order-0">
-        <li class="nav-item dropdown">
-          <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request pair_round %}{% active request view_status %}{% active request view_rounds %}">
-            Pairings
-          </a>
-          <div class="dropdown-menu">
-            <a class="dropdown-item {%active request view_status %}" href="{{ view_status }}">Current Round</a>
-            <a class="dropdown-item {%active request view_rounds %}" href="{{ view_rounds }}">All Rounds</a>
-	    <a class="dropdown-item {%active request outround_pairings %}" href="{{ outround_pairings }}">Outround Pairings</a>
-          </div>
-        </li>
-
-        <li class="nav-item dropdown">
-          <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request rank_teams %}{% active request rank_debaters %}">
-            Rankings
-          </a>
-          <div class="dropdown-menu">
-            <a class="dropdown-item {% active request rank_debaters %}" href="{{ rank_debaters }}">Debater Ranking</a>
-            <a class="dropdown-item {% active request rank_teams %}" href="{{ rank_teams }}">Team Ranking</a>
-          </div>
-        </li>
-
-        <li class="nav-item dropdown">
-          <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request tab_cards %}{% active request backup %}{% active request view_backups %}{%active request download_archive %}">
-            Backups
-          </a>
-
-          <div class="dropdown-menu">
-            <a class="dropdown-item {%active request view_backups %}" href="{{ view_backups }}">View Backups</a>
-            <a class="dropdown-item {%active request backup %}" href="{{ backup }}">Backup Current</a>
-            <a class="dropdown-item {%active request tab_cards %}" href="{{ tab_cards }}">View Tab Cards</a>
-            <a class="dropdown-item {%active request download_archive %}" href="{{ download_archive }}" title="DebateXML is an archive format to preserve tournaments and perform analyses.">Create DebateXML</a>
-          </div>
-        </li>
-
-        <li class="nav-item dropdown">
-          <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request view_scratches %}{% active request add_scratch %}">
-            Scratches
-          </a>
-          <div class="dropdown-menu">
-            <a class="dropdown-item {%active request view_scratches %}" href="{{ view_scratches }}">View Scratches</a>
-            <a class="dropdown-item {%active request add_scratch %}" href="{{ add_scratch }}">Add Scratch</a>
-          </div>
-        </li>
-
-        <li class="nav-item dropdown">
-          <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request batch_checkin %}{% active request upload_data %}{% active request confirm_start_new_tourny %}">
-            Admin
-          </a>
-          <div class="dropdown-menu">
-            <a class="dropdown-item {% active request batch_checkin %}" href="{{ batch_checkin }}">Batch Checkin</a>
-            <a class="dropdown-item {% active request upload_data %}" href="{{ upload_data }}">Bulk Data Upload</a>
-            <a class="dropdown-item {% active request settings_form %}" href="{{ settings_form }}">Settings Form</a>
-            <a class="dropdown-item {% active request confirm_start_new_tourney %}" href="{{ confirm_start_new_tourny }}">New Tournament</a>
-            <a class="dropdown-item" href="/admin">Admin Interface</a>
-          </div>
-        </li>
-	<li class="nav-item">
-        <a class="nav-link" href="{{ logout }}">Logout</a>
-	</li>
-      </ul>
+    <div class="container {% if not smaller_width %}w-95{% endif %}">
+        <a class="navbar-brand text-extra-bold{% if not user.is_authenticated %} no-nav{% endif %}"
+           href="{{ home }}">MIT-TAB</a>
+        {% if user.is_authenticated %}
+            <button class="navbar-toggler"
+                    type="button"
+                    data-toggle="collapse"
+                    data-target="#navbarSupportedContent"
+                    aria-controls="navbarSupportedContent"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                <ul class="navbar-nav mr-auto order-0">
+                    <li class="nav-item dropdown">
+                        <a data-toggle="dropdown"
+                           class="nav-link dropdown-toggle {% active request pair_round %}{% active request view_status %}{% active request view_rounds %}">
+                            Pairings
+                        </a>
+                        <div class="dropdown-menu">
+                            <a class="dropdown-item {% active request view_status %}"
+                               href="{{ view_status }}">Current Round</a>
+                            <a class="dropdown-item {% active request view_rounds %}"
+                               href="{{ view_rounds }}">All Rounds</a>
+                            <a class="dropdown-item {% active request outround_pairings %}"
+                               href="{{ outround_pairings }}">Outround Pairings</a>
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a data-toggle="dropdown"
+                           class="nav-link dropdown-toggle {% active request rank_teams %}{% active request rank_debaters %}">
+                            Rankings
+                        </a>
+                        <div class="dropdown-menu">
+                            <a class="dropdown-item {% active request rank_debaters %}"
+                               href="{{ rank_debaters }}">Debater Ranking</a>
+                            <a class="dropdown-item {% active request rank_teams %}"
+                               href="{{ rank_teams }}">Team Ranking</a>
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a data-toggle="dropdown"
+                           class="nav-link dropdown-toggle {% active request tab_cards %}{% active request backup %}{% active request view_backups %}{% active request download_archive %}">
+                            Backups
+                        </a>
+                        <div class="dropdown-menu">
+                            <a class="dropdown-item {% active request view_backups %}"
+                               href="{{ view_backups }}">View Backups</a>
+                            <a class="dropdown-item {% active request backup %}" href="{{ backup }}">Backup Current</a>
+                            <a class="dropdown-item {% active request tab_cards %}"
+                               href="{{ tab_cards }}">View Tab Cards</a>
+                            <a class="dropdown-item {% active request download_archive %}"
+                               href="{{ download_archive }}"
+                               title="DebateXML is an archive format to preserve tournaments and perform analyses.">Create DebateXML</a>
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a data-toggle="dropdown"
+                           class="nav-link dropdown-toggle {% active request view_scratches %}{% active request add_scratch %}">
+                            Scratches
+                        </a>
+                        <div class="dropdown-menu">
+                            <a class="dropdown-item {% active request view_scratches %}"
+                               href="{{ view_scratches }}">View Scratches</a>
+                            <a class="dropdown-item {% active request add_scratch %}"
+                               href="{{ add_scratch }}">Add Scratch</a>
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a data-toggle="dropdown"
+                           class="nav-link dropdown-toggle {% active request batch_checkin %}{% active request upload_data %}{% active request confirm_start_new_tourny %}">
+                            Admin
+                        </a>
+                        <div class="dropdown-menu">
+                            <a class="dropdown-item {% active request batch_checkin %}"
+                               href="{{ batch_checkin }}">Batch Checkin</a>
+                            <a class="dropdown-item {% active request upload_data %}"
+                               href="{{ upload_data }}">Bulk Data Upload</a>
+                            <a class="dropdown-item {% active request settings_form %}"
+                               href="{{ settings_form }}">Settings Form</a>
+                            <a class="dropdown-item {% active request confirm_start_new_tourney %}"
+                               href="{{ confirm_start_new_tourny }}">New Tournament</a>
+                            <a class="dropdown-item" href="/admin">Admin Interface</a>
+                        </div>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ logout }}">Logout</a>
+                    </li>
+                </ul>
+            </div>
+        {% endif %}
     </div>
-    {% endif %}
-  </div>
-  <br>
+    <br>
 </nav>

--- a/mittab/templates/batch_check_in/_judge.html
+++ b/mittab/templates/batch_check_in/_judge.html
@@ -1,49 +1,46 @@
-
 {% load tags %}
-
 {% csrf_token %}
-
 <div class="col">
-
-
-  <table class="table table-striped table-bordered table-sm">
-    <thead>
-      <th>School</th>
-      <th>Judge</th>
-      <th>Outrounds</th>
- 
-      {% for round_number in round_numbers %}<th>Round {{ round_number }}</th>{% endfor %}
-    </thead>
-    {% for schools, judge, checkins in judges_and_checkins %}
-    <tr class="searchable">
-      <td>
-        {% for school in schools %}
-              <a href="/school/{{school.id}}">{{ school.name }}</a>{% if not forloop.last %}, {% endif %}
+    <table class="table table-striped table-bordered table-sm">
+        <thead>
+            <th>School</th>
+            <th>Judge</th>
+            <th>Outrounds</th>
+            {% for round_number in round_numbers %}<th>Round {{ round_number }}</th>{% endfor %}
+        </thead>
+        {% for schools, judge, checkins in judges_and_checkins %}
+            <tr class="searchable">
+                <td>
+                    {% for school in schools %}
+                        <a href="/school/{{ school.id }}">{{ school.name }}</a>
+                        {% if not forloop.last %},{% endif %}
+                    {% endfor %}
+                </td>
+                <td>
+                    <a href="/judge/{{ judge.id }}">{{ judge.name }}</a>
+                </td>
+                {% for is_checked_in in checkins %}
+                    <td>
+                        <div class="custom-control custom-switch">
+                            <input type="checkbox"
+                                   class="custom-control-input judge-checkin-toggle"
+                                   data-judge-id="{{ judge.id }}"
+                                   data-round-number="{{ forloop.counter0 }}"
+                                   id="toggle-judge-{{ judge.id }}-{{ forloop.counter0 }}"
+                                   {% if is_checked_in %}checked{% endif %}>
+                            <label class="custom-control-label"
+                                   for="toggle-judge-{{ judge.id }}-{{ forloop.counter0 }}">
+                                Checked
+                                {% if is_checked_in %}
+                                    In
+                                {% else %}
+                                    Out
+                                {% endif %}
+                            </label>
+                        </div>
+                    </td>
+                {% endfor %}
+            </tr>
         {% endfor %}
-      </td>
-      <td>
-        <a href="/judge/{{judge.id}}">{{ judge.name }}</a>
-      </td>
-      {% for is_checked_in in checkins %}
-      <td>
-        <div class="custom-control custom-switch">
-          <input type="checkbox" class="custom-control-input judge-checkin-toggle"
-                 data-judge-id="{{judge.id}}"
-                 data-round-number="{{forloop.counter0}}"
-                 id="toggle-judge-{{ judge.id }}-{{ forloop.counter0 }}"
-                 {% if is_checked_in %}checked{% endif %}>
-          <label class="custom-control-label" for="toggle-judge-{{ judge.id }}-{{ forloop.counter0 }}">
-            Checked {% if is_checked_in %}In{% else %}Out{% endif %}
-          </label>
-        </div>
-      </td>
-      {% endfor %}
-    </tr>
-    {% endfor %}
-  </table>
+    </table>
 </div>
-
-
-
-
-

--- a/mittab/templates/batch_check_in/_room.html
+++ b/mittab/templates/batch_check_in/_room.html
@@ -1,35 +1,39 @@
 {% load tags %}
 {% csrf_token %}
-
 <div class="col">
-
-  <table class="table table-striped table-bordered table-sm">
-    <thead>
-	<th>Room</th>
-	<th>Outrounds</th>
-	
-      {% for round_number in round_numbers %}<th>Round {{ round_number }}</th>{% endfor %}
-    </thead>
-    {% for room, checkins in rooms_and_checkins %}
-    <tr class="searchable">
-      <td>
-        <a href="/room/{{room.id}}">{{ room.name }}</a>
-      </td>
-      {% for is_checked_in in checkins %}
-      <td>
-        <div class="custom-control custom-switch">
-          <input type="checkbox" class="custom-control-input room-checkin-toggle"
-                 data-room-id="{{room.id}}"
-                 data-round-number="{{forloop.counter0}}"
-                 id="toggle-room-{{ room.id }}-{{ forloop.counter0 }}"
-                 {% if is_checked_in %}checked{% endif %}>
-          <label class="custom-control-label" for="toggle-room-{{ room.id }}-{{ forloop.counter0 }}">
-            Checked {% if is_checked_in %}In{% else %}Out{% endif %}
-          </label>
-        </div>
-      </td>
-      {% endfor %}
-    </tr>
-    {% endfor %}
-  </table>
+    <table class="table table-striped table-bordered table-sm">
+        <thead>
+            <th>Room</th>
+            <th>Outrounds</th>
+            {% for round_number in round_numbers %}<th>Round {{ round_number }}</th>{% endfor %}
+        </thead>
+        {% for room, checkins in rooms_and_checkins %}
+            <tr class="searchable">
+                <td>
+                    <a href="/room/{{ room.id }}">{{ room.name }}</a>
+                </td>
+                {% for is_checked_in in checkins %}
+                    <td>
+                        <div class="custom-control custom-switch">
+                            <input type="checkbox"
+                                   class="custom-control-input room-checkin-toggle"
+                                   data-room-id="{{ room.id }}"
+                                   data-round-number="{{ forloop.counter0 }}"
+                                   id="toggle-room-{{ room.id }}-{{ forloop.counter0 }}"
+                                   {% if is_checked_in %}checked{% endif %}>
+                            <label class="custom-control-label"
+                                   for="toggle-room-{{ room.id }}-{{ forloop.counter0 }}">
+                                Checked
+                                {% if is_checked_in %}
+                                    In
+                                {% else %}
+                                    Out
+                                {% endif %}
+                            </label>
+                        </div>
+                    </td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    </table>
 </div>

--- a/mittab/templates/batch_check_in/_team.html
+++ b/mittab/templates/batch_check_in/_team.html
@@ -1,42 +1,46 @@
 {% load tags %}
-
 {% csrf_token %}
-
 <div class="col">
-  
-
-  <table class="table table-striped table-bordered table-sm">
-    <thead>
-      <th>School</th>
-      <th>Team</th>
-      <th>Debater Names</th>
-      <th>Checked In?</th>
-	
-    </thead>
-    {% for school, team, debaters, checked_in in teams_and_checkins %}
-    <tr class="searchable">
-      <td>
-        <a href="/school/{{school.id}}">{{ school }}</a>
-      </td>
-      <td>
-        <a href="/team/{{team.id}}">{{ team.name }}</a>
-      </td>
-      <td>
-        {% for debater in debaters %}
-          {{ debater.name }}{% if not forloop.last %} and {% endif %}
-        {% endfor %}
-      <td>
-        <div class="custom-control custom-switch">
-          <input type="checkbox" class="custom-control-input team-checkin-toggle"
-                 data-team-id="{{team.id}}"
-                 id="toggle-team-{{ team.id }}-{{ forloop.counter0 }}"
-                 {% if checked_in %}checked{% endif %}>
-          <label class="custom-control-label" for="toggle-team-{{ team.id }}-{{ forloop.counter0 }}">
-            Checked {% if checked_in %}In{% else %}Out{% endif %}
-          </label>
-        </div>
-      </td>
-    </tr>
-    {% endfor %}
-  </table>
-</div>
+    <table class="table table-striped table-bordered table-sm">
+        <thead>
+            <th>School</th>
+            <th>Team</th>
+            <th>Debater Names</th>
+            <th>Checked In?</th>
+        </thead>
+        {% for school, team, debaters, checked_in in teams_and_checkins %}
+            <tr class="searchable">
+                <td>
+                    <a href="/school/{{ school.id }}">{{ school }}</a>
+                </td>
+                <td>
+                    <a href="/team/{{ team.id }}">{{ team.name }}</a>
+                </td>
+                <td>
+                    {% for debater in debaters %}
+                        {{ debater.name }}
+                        {% if not forloop.last %}and{% endif %}
+                    {% endfor %}
+                </td>
+                    <td>
+                        <div class="custom-control custom-switch">
+                            <input type="checkbox"
+                                   class="custom-control-input team-checkin-toggle"
+                                   data-team-id="{{ team.id }}"
+                                   id="toggle-team-{{ team.id }}-{{ forloop.counter0 }}"
+                                   {% if checked_in %}checked{% endif %}>
+                            <label class="custom-control-label"
+                                   for="toggle-team-{{ team.id }}-{{ forloop.counter0 }}">
+                                Checked
+                                {% if checked_in %}
+                                    In
+                                {% else %}
+                                    Out
+                                {% endif %}
+                            </label>
+                        </div>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>

--- a/mittab/templates/batch_check_in/check_in.html
+++ b/mittab/templates/batch_check_in/check_in.html
@@ -1,35 +1,58 @@
 {% extends "base/__normal.html" %}
 {% load tags %}
-
-{% block title %}Check-In{% endblock %}
-{% block banner %}Batch Check-In{% endblock %}
-
+{% block title %}
+    Check-In
+{% endblock title %}
+{% block banner %}
+    Batch Check-In
+{% endblock banner %}
 {% block content %}
-
-<div class="container mt-2">
+    <div class="container mt-2">
         <div class="mb-4">
             {% quick_search %}
             <ul class="nav nav-tabs mb-3" role="tablist">
-                        <li class="nav-item" role="presentation">
-                            <a class="nav-link active" id="team-tab" data-toggle="tab" href="#team" role="tab" aria-controls="team" aria-selected="true">Team</a>
-                        </li>
-                        <li class="nav-item" role="presentation">
-                           <a class="nav-link" id="judge-tab" data-toggle="tab" href="#judge" role="tab" aria-controls="judge" aria-selected="false">Judge</a>
-                       </li>
-                        <li class="nav-item" role="presentation">
-                            <a class="nav-link" id="room-tab" data-toggle="tab" href="#room" role="tab" aria-controls="room" aria-selected="false">Room</a>
-                        </li>
-                    </ul>
-                
-                    <div class="tab-content">
-                    <div class="tab-pane fade show active" id="team" role="tabpanel" aria-labelledby="team-tab">
-                           {% include "batch_check_in/_team.html" %}
-                       </div>
-                  <div class="tab-pane fade" id="judge" role="tabpanel" aria-labelledby="judge-tab">
-                           {% include "batch_check_in/_judge.html" %}
-                   </div>
-                       <div class="tab-pane fade" id="room" role="tabpanel" aria-labelledby="room-tab">
-                            {% include "batch_check_in/_room.html" %}
-                        </div>
-
-                        {% endblock %}
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link active"
+                       id="team-tab"
+                       data-toggle="tab"
+                       href="#team"
+                       role="tab"
+                       aria-controls="team"
+                       aria-selected="true">Team</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link"
+                       id="judge-tab"
+                       data-toggle="tab"
+                       href="#judge"
+                       role="tab"
+                       aria-controls="judge"
+                       aria-selected="false">Judge</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link"
+                       id="room-tab"
+                       data-toggle="tab"
+                       href="#room"
+                       role="tab"
+                       aria-controls="room"
+                       aria-selected="false">Room</a>
+                </li>
+            </ul>
+            <div class="tab-content">
+                <div class="tab-pane fade show active"
+                     id="team"
+                     role="tabpanel"
+                     aria-labelledby="team-tab">{% include "batch_check_in/_team.html" %}</div>
+                <div class="tab-pane fade"
+                     id="judge"
+                     role="tabpanel"
+                     aria-labelledby="judge-tab">{% include "batch_check_in/_judge.html" %}</div>
+                <div class="tab-pane fade"
+                     id="room"
+                     role="tabpanel"
+                     aria-labelledby="room-tab">{% include "batch_check_in/_room.html" %}</div>
+            {% endblock content %}
+            </div>
+        </div>
+    </div>

--- a/mittab/templates/common/403.html
+++ b/mittab/templates/common/403.html
@@ -1,14 +1,15 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}ERROR!{% endblock %}
-
+{% load static %}
+{% block title %}
+    ERROR!
+{% endblock title %}
 {% block content %}
-<div class="col">
-  <center>
-    <h1>Error: Unauthorized</h1>
-    <img src="/static/img/gandalf.png" alt="403">
-    <br/>
-    <p class="lead">Please do not try to do things you're not supposed to.</p>
-  </center>
-</div>
-{% endblock %}
+    <div class="col">
+        <center>
+            <h1>Error: Unauthorized</h1>
+            <img src="{% static 'img/gandalf.png' %}" alt="403" height="300" width="300">
+            <br />
+            <p class="lead">Please do not try to do things you're not supposed to.</p>
+        </center>
+    </div>
+{% endblock content %}

--- a/mittab/templates/common/404.html
+++ b/mittab/templates/common/404.html
@@ -1,12 +1,12 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}ERROR!{% endblock %}
-
+{% block title %}
+    ERROR!
+{% endblock title %}
 {% block content %}
-<div class="col">
-  <center>
-    <h1>404: Not Found</h1>
-    <p class="lead">Page not found. Check for any typos in the URL</p>
-  </center>
-</div>
-{% endblock %}
+    <div class="col">
+        <center>
+            <h1>404: Not Found</h1>
+            <p class="lead">Page not found. Check for any typos in the URL</p>
+        </center>
+    </div>
+{% endblock content %}

--- a/mittab/templates/common/500.html
+++ b/mittab/templates/common/500.html
@@ -1,15 +1,15 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}ERROR!{% endblock %}
-
+{% block title %}
+    ERROR!
+{% endblock title %}
 {% block content %}
-<div class="col">
-  <center>
-    <h1>500: Server Error</h1>
-    <p class="lead">
-      A server error occurred. If you were modifying data, check whether or not
-      the changes were peristed.
-    </p>
-  </center>
-</div>
-{% endblock %}
+    <div class="col">
+        <center>
+            <h1>500: Server Error</h1>
+            <p class="lead">
+                A server error occurred. If you were modifying data, check whether or not
+                the changes were peristed.
+            </p>
+        </center>
+    </div>
+{% endblock content %}

--- a/mittab/templates/common/_file_field.html
+++ b/mittab/templates/common/_file_field.html
@@ -1,9 +1,9 @@
 <div class="custom-file form-group">
-  <input type="file" name="{{field.name}}"
-                     class="custom-file-input" id="custom-file-{{field.name}}"/>
-  <label class="custom-file-label" for="custom-file-{{field.name}}">
-    {{field.label}}
-  </label>
+    <input type="file"
+           name="{{ field.name }}"
+           class="custom-file-input"
+           id="custom-file-{{ field.name }}" />
+    <label class="custom-file-label" for="custom-file-{{ field.name }}">{{ field.label }}</label>
 </div>
-<br/>
-<br/>
+<br />
+<br />

--- a/mittab/templates/common/_form.html
+++ b/mittab/templates/common/_form.html
@@ -1,18 +1,19 @@
 {% load bootstrap4 %}
 {% load tags %}
-
 {{ form.media }}
-<form action="{{ action }}" method="post" id="data-entry-form" enctype="multipart/form-data">{% csrf_token %}
-  {% bootstrap_form form exclude='file,team_file,judge_file,room_file,scratch_file' %}
-
-  {% for field in form %}
-    {% if field|is_file_field %}
-      {% include "common/_file_field.html" %}
-    {% endif %}
-  {% endfor %}
-
-  {% csrf_token %}
-  {% buttons %}
-    <input type="submit" value="Save" class="btn btn-primary"/>
-  {% endbuttons %}
+<form action="{{ action }}"
+      method="post"
+      id="data-entry-form"
+      enctype="multipart/form-data">
+    {% csrf_token %}
+    {% bootstrap_form form exclude='file,team_file,judge_file,room_file,scratch_file' %}
+    {% for field in form %}
+        {% if field|is_file_field %}
+            {% include "common/_file_field.html" %}
+        {% endif %}
+    {% endfor %}
+    {% csrf_token %}
+    {% buttons %}
+    <input type="submit" value="Save" class="btn btn-primary" />
+{% endbuttons %}
 </form>

--- a/mittab/templates/common/_index_list.html
+++ b/mittab/templates/common/_index_list.html
@@ -1,23 +1,26 @@
 <div class="col-sm" id="school_list">
-  <h4 class="text-center font-weight-normal">
-    {{count}} {{model_name}}
-    <div class="btn-group btn-group-sm">
-      <a class="btn btn-sm btn-light" href="{{ list_path }}"
-        title="List {{model_name|lower}}"
-        id="{{ html_id }}-btn-list">
-        <i class="fas fa-list"></i>
-      </a>
-      <a class="btn btn-sm btn-light" href="{{ enter_path }}"
-        title="Add {{model_name|lower}}"
-        id="{{ html_id }}-btn-add">
-        <i class="fas fa-plus"></i>
-      </a>
-    </div>
-  </h4>
-
-  <ol id="{{ html_id }}">
-    {% for id, name in list_data %}
-      <li class="searchable"><a href="/{{ view_path_prefix }}/{{ id }}/">{{ name }}</a></li>
-    {% endfor %}
-  </ol>
+    <h4 class="text-center font-weight-normal">
+        {{ count }} {{ model_name }}
+        <div class="btn-group btn-group-sm">
+            <a class="btn btn-sm btn-light"
+               href="{{ list_path }}"
+               title="List {{ model_name|lower }}"
+               id="{{ html_id }}-btn-list">
+                <i class="fas fa-list"></i>
+            </a>
+            <a class="btn btn-sm btn-light"
+               href="{{ enter_path }}"
+               title="Add {{ model_name|lower }}"
+               id="{{ html_id }}-btn-add">
+                <i class="fas fa-plus"></i>
+            </a>
+        </div>
+    </h4>
+    <ol id="{{ html_id }}">
+        {% for id, name in list_data %}
+            <li class="searchable">
+                <a href="/{{ view_path_prefix }}/{{ id }}/">{{ name }}</a>
+            </li>
+        {% endfor %}
+    </ol>
 </div>

--- a/mittab/templates/common/_quick_search.html
+++ b/mittab/templates/common/_quick_search.html
@@ -1,6 +1,6 @@
 <div class="input-group mb-3">
-  <div class="input-group-prepend">
-    <span class="input-group-text" id="basic-addon1">Quick Search:</span>
-  </div>
-  <input type="text" class="form-control" id="quick-search">
+    <div class="input-group-prepend">
+        <span class="input-group-text" id="basic-addon1">Quick Search:</span>
+    </div>
+    <input type="text" class="form-control" id="quick-search">
 </div>

--- a/mittab/templates/common/_upload_error.html
+++ b/mittab/templates/common/_upload_error.html
@@ -1,21 +1,19 @@
 {% if info_obj.uploaded %}
-  {% if info_obj.errors %}
-  <div class="alert alert-danger">
-    <h6 class="alert-heading">
-      Errors in {{ obj_type }} file, all {{ obj_type }} uploads aborted
-      <small data-toggle="collapse" class="float-right" data-target="#{{ obj_type }}-errors">
-        Show/hide errors
-      </small>
-    </h6>
-    <div class="alert-content collapse show" id="{{ obj_type }}-errors">
-      <ul>
-        {% for error in info_obj.errors %}<li>{{ error }}</li>{% endfor %}
-      </ul>
-    </div>
-  </div>
-  {% else %}
-  <div class="alert alert-success">
-    Imported {{ obj_type }} file successfully
-  </div>
-  {% endif %}
+    {% if info_obj.errors %}
+        <div class="alert alert-danger">
+            <h6 class="alert-heading">
+                Errors in {{ obj_type }} file, all {{ obj_type }} uploads aborted
+                <small data-toggle="collapse"
+                       class="float-right"
+                       data-target="#{{ obj_type }}-errors">Show/hide errors</small>
+            </h6>
+            <div class="alert-content collapse show" id="{{ obj_type }}-errors">
+                <ul>
+                    {% for error in info_obj.errors %}<li>{{ error }}</li>{% endfor %}
+                </ul>
+            </div>
+        </div>
+    {% else %}
+        <div class="alert alert-success">Imported {{ obj_type }} file successfully</div>
+    {% endif %}
 {% endif %}

--- a/mittab/templates/common/confirm.html
+++ b/mittab/templates/common/confirm.html
@@ -1,16 +1,13 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}Confirm Action{% endblock %}
-
+{% block title %}
+    Confirm Action
+{% endblock title %}
 {% block content %}
-<div class="col">
-  <center>
-    <h1>{{ title }}</h1>
-    <p class="lead">
-      This action is final. This will nuke everything, please backup and download if you are not sure.
-    </p>
-    <a class="btn btn-warning btn-lg" href='{{link}}'>{{confirm_text}}</a>
-  </center>
-</div>
-
-{% endblock %}
+    <div class="col">
+        <center>
+            <h1>{{ title }}</h1>
+            <p class="lead">This action is final. This will nuke everything, please backup and download if you are not sure.</p>
+            <a class="btn btn-warning btn-lg" href='{{ link }}'>{{ confirm_text }}</a>
+        </center>
+    </div>
+{% endblock content %}

--- a/mittab/templates/common/data_entry.html
+++ b/mittab/templates/common/data_entry.html
@@ -1,46 +1,55 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}Data Entry{% endblock %}
-
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    Data Entry
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
-<div class="col-md-6">
-  {% include "common/_form.html" %}
-</div>
-
-{% if team_obj %}
-<div class="col-md-1"></div>
-<div class="col-md-5">
-  <div class="team-record">
-    <h5>Team Stats</h5>
-    <table class="table table-striped">
-      <thead><th>Stat</th><th>Value</th></thead>
-      {% for stat,val in team_stats %}
-        <tr><td>{{stat}}</td><td>{{val}}</td></tr>
-      {% endfor %}
-    </table>
-    <a href='/team/card/{{ team_obj.id }}/pretty/' class="btn btn-link">View Tab Card</a>
-  </div>
-</div>
-{% endif %}
-
-{% if debater_obj %}
-<div class="col-md-1"></div>
-<div class="col-md-5">
-  <div class="team-record">
-    <h5>Debater Rounds</h5>
-    <table class="table table-striped">
-      <thead><th>Round #</th><th>Speaks</th><th>Ranks</th></thead>
-      {% for round in debater_rounds %}
-      <tr>
-        <td><a href='/round/{{ round.round.id }}/result/'>Round {{ round.round.round_number }}</a></td>
-          <td>{{round.speaks}}</td>
-          <td>{{round.ranks}}</td>
-      </tr>
-      {% endfor %}
-    </table>
-  </div>
-</div>
-{% endif %}
-{% endblock %}
+    <div class="col-md-6">{% include "common/_form.html" %}</div>
+    {% if team_obj %}
+        <div class="col-md-1"></div>
+        <div class="col-md-5">
+            <div class="team-record">
+                <h5>Team Stats</h5>
+                <table class="table table-striped">
+                    <thead>
+                        <th>Stat</th>
+                        <th>Value</th>
+                    </thead>
+                    {% for stat,val in team_stats %}
+                        <tr>
+                            <td>{{ stat }}</td>
+                            <td>{{ val }}</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+                <a href='/team/card/{{ team_obj.id }}/pretty/' class="btn btn-link">View Tab Card</a>
+            </div>
+        </div>
+    {% endif %}
+    {% if debater_obj %}
+        <div class="col-md-1"></div>
+        <div class="col-md-5">
+            <div class="team-record">
+                <h5>Debater Rounds</h5>
+                <table class="table table-striped">
+                    <thead>
+                        <th>Round #</th>
+                        <th>Speaks</th>
+                        <th>Ranks</th>
+                    </thead>
+                    {% for round in debater_rounds %}
+                        <tr>
+                            <td>
+                                <a href='/round/{{ round.round.id }}/result/'>Round {{ round.round.round_number }}</a>
+                            </td>
+                            <td>{{ round.speaks }}</td>
+                            <td>{{ round.ranks }}</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            </div>
+        </div>
+    {% endif %}
+{% endblock content %}

--- a/mittab/templates/common/data_entry_multiple.html
+++ b/mittab/templates/common/data_entry_multiple.html
@@ -1,35 +1,35 @@
 {% extends "base/__normal.html" %}
 {% load bootstrap4 %}
-
-{% block title %} {{title}} {% endblock %}
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    {{ title }}
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
-<div class="col-md-6">
-  <form method="post" action=""> {% csrf_token %}
-    {% for form, delete in forms %}
-    <div class="card mb-3">
-      <div class="card-header">
-        <h5 class="float-left">{{data_type}} #{{ form.prefix }}</h5>
-        {% if delete %}
-          <a class="btn btn-sm float-right btn-outline-danger"
-             confirm="Are you sure?"
-             href="{{delete}}">
-            <i class="fas fa-times"></i>
-          </a>
-        {% endif %}
-      </div>
-      <div class="card-body">
-        {% bootstrap_form form %}
-      </div>
+    <div class="col-md-6">
+        <form method="post" action="">
+            {% csrf_token %}
+            {% for form, delete in forms %}
+                <div class="card mb-3">
+                    <div class="card-header">
+                        <h5 class="float-left">{{ data_type }} #{{ form.prefix }}</h5>
+                        {% if delete %}
+                            <a class="btn btn-sm float-right btn-outline-danger"
+                               confirm="Are you sure?"
+                               href="{{ delete }}">
+                                <i class="fas fa-times"></i>
+                            </a>
+                        {% endif %}
+                    </div>
+                    <div class="card-body">{% bootstrap_form form %}</div>
+                </div>
+            {% endfor %}
+            {% if forms %}
+                <input type="submit" class="btn btn-primary" value="Submit" />
+            {% else %}
+                <p class="text-center lead">No scratches</p>
+            {% endif %}
+        </form>
     </div>
-    {% endfor %}
-
-    {% if forms %}
-    <input type="submit" class="btn btn-primary" value="Submit"/>
-    {% else %}
-    <p class="text-center lead">No scratches</p>
-    {% endif %}
-  </form>
-</div>
-{% endblock %}
+{% endblock content %}

--- a/mittab/templates/common/data_upload.html
+++ b/mittab/templates/common/data_upload.html
@@ -1,35 +1,29 @@
 {% extends "base/__normal.html" %}
-
-{% block title %} {{ title }} {% endblock %}
-
+{% block title %}
+    {{ title }}
+{% endblock title %}
 {% block content %}
-<div class="col-md-2"></div>
-<div class="col-md-8">
-  <h3 class="text-center">Upload Data Files</h3>
-  {% with obj_type="team" info_obj=team_info %}
-    {% include "common/_upload_error.html" %}
-  {% endwith %}
-
-  {% with obj_type="judge" info_obj=judge_info %}
-    {% include "common/_upload_error.html" %}
-  {% endwith %}
-
-  {% with obj_type="room" info_obj=room_info %}
-    {% include "common/_upload_error.html" %}
-  {% endwith %}
-
-  {% with obj_type="scratch" info_obj=scratch_info %}
-    {% include "common/_upload_error.html" %}
-  {% endwith %}
-
-  <p class="text-center">
-    Check out
-    <a href="https://drive.google.com/drive/folders/1ElIk0bM9uMpuewmOxb2e3-cWiLhCYv_5">
-      these templates
-    </a>
-    to get started and make sure to keep the header rows!
-  </p>
-  {% include "common/_form.html" %}
-</div>
-<div class="col-md-2"></div>
-{% endblock %}
+    <div class="col-md-2"></div>
+    <div class="col-md-8">
+        <h3 class="text-center">Upload Data Files</h3>
+        {% with obj_type="team" info_obj=team_info %}
+            {% include "common/_upload_error.html" %}
+        {% endwith %}
+        {% with obj_type="judge" info_obj=judge_info %}
+            {% include "common/_upload_error.html" %}
+        {% endwith %}
+        {% with obj_type="room" info_obj=room_info %}
+            {% include "common/_upload_error.html" %}
+        {% endwith %}
+        {% with obj_type="scratch" info_obj=scratch_info %}
+            {% include "common/_upload_error.html" %}
+        {% endwith %}
+        <p class="text-center">
+            Check out
+            <a href="https://drive.google.com/drive/folders/1ElIk0bM9uMpuewmOxb2e3-cWiLhCYv_5">these templates</a>
+            to get started and make sure to keep the header rows!
+        </p>
+        {% include "common/_form.html" %}
+    </div>
+    <div class="col-md-2"></div>
+{% endblock content %}

--- a/mittab/templates/common/index.html
+++ b/mittab/templates/common/index.html
@@ -1,68 +1,57 @@
 {% extends "base/__wide.html" %}
 {% load tags %}
-
-{% block title %}Welcome to MIT Tab{% endblock %}
-
+{% block title %}
+    Welcome to MIT Tab
+{% endblock title %}
 {% block content %}
-
-{% url "view_judges" as view_judges %}
-{% url "view_schools" as view_schools %}
-{% url "view_teams" as view_teams %}
-{% url "view_debaters" as view_debaters %}
-{% url "view_rooms" as view_rooms %}
-
-{% url "enter_judge" as enter_judge %}
-{% url "enter_school" as enter_school %}
-{% url "enter_team" as enter_team %}
-{% url "enter_debater" as enter_debater %}
-{% url "enter_room" as enter_room %}
-
-
-
-<div class="col container-fluid index">
-  {% quick_search %}
-
-  <div class="row index_container">
-
-    {% with count=number_schools model_name="Schools" list_data=school_list %}
-      {% with html_id="school-list" list_path=view_schools %}
-        {% with enter_path=enter_school view_path_prefix="school" %}
-          {% include "common/_index_list.html" %}
-        {% endwith %}
-      {% endwith %}
-    {% endwith %}
-
-    {% with count=number_judges model_name="Judges" list_data=judge_list %}
-      {% with html_id="judge-list" list_path=view_judges %}
-        {% with enter_path=enter_judge view_path_prefix="judge" %}
-          {% include "common/_index_list.html" %}
-        {% endwith %}
-      {% endwith %}
-    {% endwith %}
-
-    {% with count=number_teams model_name="Teams" list_data=team_list %}
-      {% with html_id="team-list" list_path=view_teams %}
-        {% with enter_path=enter_team view_path_prefix="team" %}
-          {% include "common/_index_list.html" %}
-        {% endwith %}
-      {% endwith %}
-    {% endwith %}
-
-    {% with count=number_debaters model_name="Debaters" list_data=debater_list %}
-      {% with html_id="debater-list" list_path=view_debaters %}
-        {% with enter_path=enter_debater view_path_prefix="debater" %}
-          {% include "common/_index_list.html" %}
-        {% endwith %}
-      {% endwith %}
-    {% endwith %}
-
-    {% with count=number_rooms model_name="Rooms" list_data=room_list %}
-      {% with html_id="room-list" list_path=view_rooms %}
-        {% with enter_path=enter_room view_path_prefix="room" %}
-          {% include "common/_index_list.html" %}
-        {% endwith %}
-      {% endwith %}
-    {% endwith %}
-  </div>
-</div>
-{% endblock %}
+    {% url "view_judges" as view_judges %}
+    {% url "view_schools" as view_schools %}
+    {% url "view_teams" as view_teams %}
+    {% url "view_debaters" as view_debaters %}
+    {% url "view_rooms" as view_rooms %}
+    {% url "enter_judge" as enter_judge %}
+    {% url "enter_school" as enter_school %}
+    {% url "enter_team" as enter_team %}
+    {% url "enter_debater" as enter_debater %}
+    {% url "enter_room" as enter_room %}
+    <div class="col container-fluid index">
+        {% quick_search %}
+        <div class="row index_container">
+            {% with count=number_schools model_name="Schools" list_data=school_list %}
+                {% with html_id="school-list" list_path=view_schools %}
+                    {% with enter_path=enter_school view_path_prefix="school" %}
+                        {% include "common/_index_list.html" %}
+                    {% endwith %}
+                {% endwith %}
+            {% endwith %}
+            {% with count=number_judges model_name="Judges" list_data=judge_list %}
+                {% with html_id="judge-list" list_path=view_judges %}
+                    {% with enter_path=enter_judge view_path_prefix="judge" %}
+                        {% include "common/_index_list.html" %}
+                    {% endwith %}
+                {% endwith %}
+            {% endwith %}
+            {% with count=number_teams model_name="Teams" list_data=team_list %}
+                {% with html_id="team-list" list_path=view_teams %}
+                    {% with enter_path=enter_team view_path_prefix="team" %}
+                        {% include "common/_index_list.html" %}
+                    {% endwith %}
+                {% endwith %}
+            {% endwith %}
+            {% with count=number_debaters model_name="Debaters" list_data=debater_list %}
+                {% with html_id="debater-list" list_path=view_debaters %}
+                    {% with enter_path=enter_debater view_path_prefix="debater" %}
+                        {% include "common/_index_list.html" %}
+                    {% endwith %}
+                {% endwith %}
+            {% endwith %}
+            {% with count=number_rooms model_name="Rooms" list_data=room_list %}
+                {% with html_id="room-list" list_path=view_rooms %}
+                    {% with enter_path=enter_room view_path_prefix="room" %}
+                        {% include "common/_index_list.html" %}
+                    {% endwith %}
+                {% endwith %}
+            {% endwith %}
+        </div>
+    </div>
+{% endblock content %}

--- a/mittab/templates/common/list_data.html
+++ b/mittab/templates/common/list_data.html
@@ -1,61 +1,56 @@
 {% extends "base/__wide.html" %}
 {% load tags %}
-
-{% block title %}Data Entry{% endblock %}
-
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    Data Entry
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
-<div class="col">
-  {% quick_search %}
-  <div class="data-list">
-    <ul class="list_item">
-      {% for id, item, flags, symbols in item_list%}
-        <li class="searchable filterable {% if forloop.counter0|divisibleby:2 %}even{%else%}odd{%endif%}" data-filters="{{flags}}">
-          <a class="no_decoration" href="/{{item_type}}/{{id}}">{{item}} {{symbols}}</a>
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
-
-{% if filters %}
-<div class="col-4">
-  <div class="card mb-2">
-    <div class="card-header">Quick Filters</div>
-    <div class="card-body">
-      <ul class="list-group">
-        {% for filter_group in filters %}
-          {% for key, value in filter_group %}
-            <li class="list-group-item">
-              <div class="form-check">
-                <input class="form-check-input filter" type="checkbox" value="{{value}}"
-                      id="filter-{{key}}"
-                      data-filter-group="{{forloop.parent.counter}}"
-                      data-filter="{{key}}"/>
-                <label class="form-check-label" for="filter-{{key}}">
-                  {{value}}
-                </label>
-              </div>
-            </li>
-          {% endfor %}
-        {% endfor %}
-      </ul>
-
-      {% if symbol_text%}
-        <div class="symbol-legend mt-4">
-          {% for key, value in symbol_text %}
-          <span>{{key}}<small class="text-muted"> = {{value}}</small></span>
-          {% endfor %}
+    <div class="col">
+        {% quick_search %}
+        <div class="data-list">
+            <ul class="list_item">
+                {% for id, item, flags, symbols in item_list %}
+                    <li class="searchable filterable {% if forloop.counter0|divisibleby:2 %}even{% else %}odd{% endif %}"
+                        data-filters="{{ flags }}">
+                        <a class="no_decoration" href="/{{ item_type }}/{{ id }}">{{ item }} {{ symbols }}</a>
+                    </li>
+                {% endfor %}
+            </ul>
         </div>
-      {% endif %}
     </div>
-  </div>
-</div>
-{% endif %}
-
-
-<div class="clear"></div>
-
-<div class="clear"></div>
-{% endblock %}
+    {% if filters %}
+        <div class="col-4">
+            <div class="card mb-2">
+                <div class="card-header">Quick Filters</div>
+                <div class="card-body">
+                    <ul class="list-group">
+                        {% for filter_group in filters %}
+                            {% for key, value in filter_group %}
+                                <li class="list-group-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input filter"
+                                               type="checkbox"
+                                               value="{{ value }}"
+                                               id="filter-{{ key }}"
+                                               data-filter-group="{{ forloop.parent.counter }}"
+                                               data-filter="{{ key }}" />
+                                        <label class="form-check-label" for="filter-{{ key }}">{{ value }}</label>
+                                    </div>
+                                </li>
+                            {% endfor %}
+                        {% endfor %}
+                    </ul>
+                    {% if symbol_text %}
+                        <div class="symbol-legend mt-4">
+                            {% for key, value in symbol_text %}<span>{{ key }}<small class="text-muted">= {{ value }}</small></span>{% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+    <div class="clear"></div>
+    <div class="clear"></div>
+{% endblock content %}

--- a/mittab/templates/outrounds/_form.html
+++ b/mittab/templates/outrounds/_form.html
@@ -1,24 +1,17 @@
 {% load bootstrap4 %}
-
 {% if form.errors %}
-  <div class="alert alert-danger">
-    Please correct the error{{ form.errors|pluralize }} below.
-
-    {% bootstrap_form_errors form type='non_fields' %}
-  </div>
-{% endif %}
-
-{{ form.media }}
-
-{% for hidden in form.hidden_fields %}
-  {{ hidden }}
-{% endfor %}
-
-<div class="row">
-  <div class="form-group col-md-6">
-    {% bootstrap_field form.winner %}
-    <div class="mt-2">
-      <div class="hidden winner" data-option=0>Please select a winner</div>
+    <div class="alert alert-danger">
+        Please correct the error{{ form.errors|pluralize }} below.
+        {% bootstrap_form_errors form type='non_fields' %}
     </div>
-  </div>
+{% endif %}
+{{ form.media }}
+{% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
+<div class="row">
+    <div class="form-group col-md-6">
+        {% bootstrap_field form.winner %}
+        <div class="mt-2">
+            <div class="hidden winner" data-option=0>Please select a winner</div>
+        </div>
+    </div>
 </div>

--- a/mittab/templates/outrounds/ballot.html
+++ b/mittab/templates/outrounds/ballot.html
@@ -1,24 +1,26 @@
 {% extends "base/__wide.html" %}
 {% load tags %}
-
-{% block title %}Data Entry{% endblock %}
-
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    Data Entry
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
-
-<div class="col">
-  <div class="container-fluid">
-    <form action="{{ action }}" method="post" class="ballot-form single" enctype="multipart/form-data">{% csrf_token %}
-    {% outround_form form %}
-
-    <div class="row">
-      <div class="col mt-2">
-        <input class="btn btn-primary" type="submit" value="Save"/>
-      </div>
+    <div class="col">
+        <div class="container-fluid">
+            <form action="{{ action }}"
+                  method="post"
+                  class="ballot-form single"
+                  enctype="multipart/form-data">
+                {% csrf_token %}
+                {% outround_form form %}
+                <div class="row">
+                    <div class="col mt-2">
+                        <input class="btn btn-primary" type="submit" value="Save" />
+                    </div>
+                </div>
+            </form>
+        </div>
     </div>
-    </form>
-  </div>
-</div>
-
-{% endblock %}
+{% endblock content %}

--- a/mittab/templates/outrounds/forum_result.html
+++ b/mittab/templates/outrounds/forum_result.html
@@ -1,20 +1,16 @@
 <!DOCTYPE html>
-
-<html>
-<head>
-    <title>Forum Result Display</title>
-
-    <style type="text/css">
-    </style>
-</head>
-
-<body>
-    {% for category in results %}
-	<h1>{{ category.label }}</h1>
-	
-	{% for result in category.results %}
-	    {{ result }}
-	    <br>
-	{% endfor %}
-    {% endfor %}
-</body>
+<html lang="en">
+    <head>
+        <title>Forum Result Display</title>
+        <style type="text/css"></style>
+    </head>
+    <body>
+        {% for category in results %}
+            <h1>{{ category.label }}</h1>
+            {% for result in category.results %}
+                {{ result }}
+                <br>
+            {% endfor %}
+        {% endfor %}
+    </body>
+</html>

--- a/mittab/templates/outrounds/pairing_base.html
+++ b/mittab/templates/outrounds/pairing_base.html
@@ -1,114 +1,129 @@
 {% extends "base/__wide.html" %}
-
 {% load tags %}
-
-{% block title %}Round Status{% endblock %}
-
+{% block title %}
+    Round Status
+{% endblock title %}
 {% block content %}
     <div class="col">
-  <div class="containter">
-      <div class="row">
-    <div class="col">
-        <h3>
-      Round Status for {{ label }}
-      <small class="{% if not errors or num_excluded == 0 %}text-success{% else %}text-danger{% endif %}">
-          {% if not errors or num_excluded == 0 %} Valid {% else %} Invalid {% endif %} pairing
-      </small>
-        </h3>
-    </div>
-    <div class="col">
-        <ul class="nav nav-tabs">
-      {% for outround in outround_options %}
-          <li class="nav-item">
-        <a class="nav-link {% active request outround.0 %}" href="{{ outround.0 }}">{{ outround.1 }}</a>
-          </li>
-      {% endfor %}
-        </ul>
-    </div>
-      </div> <!-- end heading row -->
-      <hr />
-      <div class="row mb-3">
-    <div class="col-8">
-        <h6>Pairing Controls</h6>
-        <form action="/pairing/assign_judges/"
-        method="post"
-        onsubmit="return confirm('Do you really want to assign judges. All previous assignments will be lost.  If you are unsure, click cancel and back up')"> {% csrf_token %}
-      <div class="btn-group btn-group-sm">
-          <a class="btn btn-success outround-release {% if not pairing_released %}d-none{% endif %}" href="#"
-             id="close-pairings"
-             data-num_teams="{{ num_teams }}"
-             data-type_of_round="{{ type_of_round }}"
-             title="Release the pairings to the participants">
-        <i class="fas fa-door-closed"></i> Close Pairings
-          </a>
-          <a class="btn btn-warning outround-release {% if pairing_released %}d-none{% endif %}" href="#"
-             id="release-pairings"
-             data-num_teams="{{ num_teams }}"
-             data-type_of_round="{{ type_of_round }}"
-             title="Release the pairings to the participants">
-        <i class="fas fa-door-open"></i> Release Pairings
-          </a>
-          {% if num_teams > 2 %}
-        <a class="btn btn-info" href="/outround_pairing/pair/{{ type_of_round }}/{{ num_teams }}"
-           title="Pair the next round of debate">
-            <i class="fas fa-arrow-right"></i> Prepare Next Round
-        </a>
-          {% endif %}
-      </div>
-        </form>
-    </div>
-
-    <div class="col-4">
-        <h6>Display Options</h6>
-        <div class="btn-group btn-group-sm">
-      <a class="btn btn-secondary" href="/outround_pairings/pairinglist/{{ type_of_round }}/" title="To display in GA">
-          <i class="fas fa-tv"></i> Announcement View
-      </a>
-      <a class="btn btn-secondary" href="/outround_pairings/pairinglist/printable/{{ type_of_round }}/" title="Printable version of the GA view">
-          <i class="fas fa-print"></i> Printable View
-      </a>
-      <a class="btn btn-secondary" href="/outround_result/{{ type_of_round }}">
-          Forum View
-      </a>
+        <div class="containter">
+            <div class="row">
+                <div class="col">
+                    <h3>
+                        Round Status for {{ label }}
+                        <small class="{% if not errors or num_excluded == 0 %}text-success{% else %}text-danger{% endif %}">
+                            {% if not errors or num_excluded == 0 %}
+                                Valid
+                            {% else %}
+                                Invalid
+                            {% endif %}
+                            pairing
+                        </small>
+                    </h3>
+                </div>
+                <div class="col">
+                    <ul class="nav nav-tabs">
+                        {% for outround in outround_options %}
+                            <li class="nav-item">
+                                <a class="nav-link {% active request outround.0 %}"
+                                   href="{{ outround.0 }}">{{ outround.1 }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            <!-- end heading row -->
+            <hr />
+            <div class="row mb-3">
+                <div class="col-8">
+                    <h6>Pairing Controls</h6>
+                    <form action="/pairing/assign_judges/"
+                          method="post"
+                          onsubmit="return confirm('Do you really want to assign judges. All previous assignments will be lost.  If you are unsure, click cancel and back up')">
+                        {% csrf_token %}
+                        <div class="btn-group btn-group-sm">
+                            <a class="btn btn-success outround-release {% if not pairing_released %}d-none{% endif %}"
+                               href="#"
+                               id="close-pairings"
+                               data-num_teams="{{ num_teams }}"
+                               data-type_of_round="{{ type_of_round }}"
+                               title="Release the pairings to the participants">
+                                <i class="fas fa-door-closed"></i> Close Pairings
+                            </a>
+                            <a class="btn btn-warning outround-release {% if pairing_released %}d-none{% endif %}"
+                               href="#"
+                               id="release-pairings"
+                               data-num_teams="{{ num_teams }}"
+                               data-type_of_round="{{ type_of_round }}"
+                               title="Release the pairings to the participants">
+                                <i class="fas fa-door-open"></i> Release Pairings
+                            </a>
+                            {% if num_teams > 2 %}
+                                <a class="btn btn-info"
+                                   href="/outround_pairing/pair/{{ type_of_round }}/{{ num_teams }}"
+                                   title="Pair the next round of debate">
+                                    <i class="fas fa-arrow-right"></i> Prepare Next Round
+                                </a>
+                            {% endif %}
+                        </div>
+                    </form>
+                </div>
+                <div class="col-4">
+                    <h6>Display Options</h6>
+                    <div class="btn-group btn-group-sm">
+                        <a class="btn btn-secondary"
+                           href="/outround_pairings/pairinglist/{{ type_of_round }}/"
+                           title="To display in GA">
+                            <i class="fas fa-tv"></i> Announcement View
+                        </a>
+                        <a class="btn btn-secondary"
+                           href="/outround_pairings/pairinglist/printable/{{ type_of_round }}/"
+                           title="Printable version of the GA view">
+                            <i class="fas fa-print"></i> Printable View
+                        </a>
+                        <a class="btn btn-secondary" href="/outround_result/{{ type_of_round }}">Forum View</a>
+                    </div>
+                </div>
+            </div>
+            <!-- end control row -->
+            <div class="row">
+                {% for pairing in outrounds %}
+                    <div class="col-xl-6">{% include "outrounds/pairing_card.html" %}</div>
+                {% endfor %}
+            </div>
+            <!-- end pairings row -->
+            <div class="row mt-2 mb-2">
+                <div class="col not-paired-in overflow-auto border-bottom">
+                    <h5>People Not Paired In</h5>
+                    <table class="table table-striped table-sm">
+                        <thead>
+                            <th>Unpaired in Teams ({{ excluded_teams|length }})</th>
+                            <th>Checked in Judges ({{ excluded_judges|length }})</th>
+                            <th>Non Checked in Judges ({{ non_checkins|length }})</th>
+                            <th>Available Rooms ({{ available_rooms|length }})</th>
+                        </thead>
+                        {% for team, cjudge, judge, room in excluded_people %}
+                            <tr>
+                                <td>
+                                    {% if team %}<a href="/team/{{ team.id }}">{{ team.name }}</a>{% endif %}
+                                </td>
+                                <td>
+                                    {% if cjudge %}<a href="/judge/{{ cjudge.id }}">{{ cjudge.name }}</a>{% endif %}
+                                </td>
+                                <td>
+                                    {% if judge %}
+                                        <a class="{% if judge.rank > warning %}text-danger{% endif %}"
+                                           href="/judge/{{ judge.id }}">{{ judge.name }}</a>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if room %}<a href="/room/{{ room.id }}">{{ room.name }}</a>{% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            </div>
+            <!-- end not-paired-in row -->
         </div>
     </div>
-      </div> <!-- end control row -->
-      <div class="row">
-    {% for pairing in outrounds %}
-        <div class="col-xl-6">
-      {% include "outrounds/pairing_card.html" %}
-        </div>
-    {% endfor %}
-      </div> <!-- end pairings row -->
-      <div class="row mt-2 mb-2">
-    <div class="col not-paired-in overflow-auto border-bottom">
-        <h5>People Not Paired In</h5>
-        <table class="table table-striped table-sm">
-      <thead>
-          <th>Unpaired in Teams ({{ excluded_teams|length }})</th>
-          <th>Checked in Judges ({{ excluded_judges|length }})</th>
-          <th>Non Checked in Judges ({{ non_checkins|length }})</th>
-          <th>Available Rooms ({{ available_rooms|length }})</th>
-      </thead>
-      {% for team, cjudge, judge, room in excluded_people %}
-          <tr>
-        <td>
-            {% if team %} <a href="/team/{{team.id}}" >{{team.name}}</a> {% endif %}
-        </td>
-        <td>
-            {% if cjudge %} <a href="/judge/{{cjudge.id}}" >{{cjudge.name}}</a> {% endif %}
-        </td>
-        <td>
-            {% if judge %} <a class="{% if judge.rank > warning %}text-danger{%endif%}"href="/judge/{{judge.id}}" >{{judge.name}}</a> {% endif %}
-        </td>
-        <td>
-            {% if room %} <a href="/room/{{room.id}}" >{{room.name}}</a> {% endif %}
-        </td>
-          </tr>
-      {% endfor %}
-        </table>
-    </div>
-      </div><!-- end not-paired-in row -->
-  </div>
-    </div>
-{% endblock %}
+{% endblock content %}

--- a/mittab/templates/outrounds/pairing_card.html
+++ b/mittab/templates/outrounds/pairing_card.html
@@ -1,137 +1,132 @@
 <div class="card bg-light pairing-card mb-3">
-  <div class="card-body container-fluid">
-    <div class="row" round-id="{{pairing.id}}">
-
-      <div class="col-5">
-        <table class="table table-borderless table-sm mb-0 team-table">
-          <tr>
-            <td>
-              <h6 class="gov-team">
-                <a href="/team/{{pairing.gov_team.id}}" class="text-dark team-link">
-                  {{pairing.gov_team.display_backend}}
+    <div class="card-body container-fluid">
+        <div class="row" round-id="{{ pairing.id }}">
+            <div class="col-5">
+                <table class="table table-borderless table-sm mb-0 team-table">
+                    <tr>
+                        <td>
+                            <h6 class="gov-team">
+                                <a href="/team/{{ pairing.gov_team.id }}" class="text-dark team-link">{{ pairing.gov_team.display_backend }}</a>
+                                <small>
+                                    <abbr title="Gov Team" class="attribute">GOV</abbr>
+                                    <span class="team-assign-button"
+                                          round-id="{{ pairing.id }}"
+                                          position="gov"
+                                          team-id="{{ pairing.gov_team.id }}">
+                                        <a class="dropdown-toggle outround-team-toggle text-dark"
+                                           data-toggle="dropdown"
+                                           href="#"
+                                           title="Swap teams">
+                                            <span class="caret"></span>
+                                        </a>
+                                        <ul class="dropdown-menu">
+                                        </ul>
+                                    </span>
+                                    <br />
+                                    <a class="text-muted team outround-tabcard pt-1"
+                                       team-id="{{ pairing.gov_team.id }}">Loading results...</a>
+                                </small>
+                            </h6>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <h6 class="opp-team">
+                                <a href="/team/{{ pairing.opp_team.id }}" class="team-link text-dark">{{ pairing.opp_team.display_backend }}</a>
+                                <small>
+                                    <abbr title="Opp Team" class="attribute">OPP</abbr>
+                                    <span class="team-assign-button"
+                                          round-id="{{ pairing.id }}"
+                                          position="opp"
+                                          team-id="{{ pairing.opp_team.id }}">
+                                        <a class="dropdown-toggle outround-team-toggle text-dark"
+                                           data-toggle="dropdown"
+                                           href="#"
+                                           title="Swap teams">
+                                            <span class="caret"></span>
+                                        </a>
+                                        <ul class="dropdown-menu">
+                                        </ul>
+                                    </span>
+                                    <br />
+                                    <a class="text-muted team outround-tabcard pt-1"
+                                       team-id="{{ pairing.opp_team.id }}">Loading results...</a>
+                                </small>
+                            </h6>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="col-4 judges">
+                {% for judge in pairing.judges.all %}
+                    <span round-id="{{ pairing.id }}" judge-id="{{ judge.id }}">
+                        <a class="btn-sm btn-light outround-judge-toggle dropdown-toggle{% if pairing.chair == judge %} chair{% endif %}"
+                           data-toggle="dropdown"
+                           href="#">
+                            {{ judge.name }} <small>({{ judge.rank }})</small>
+                        </a>
+                        <ul class="dropdown-menu">
+                        </ul>
+                    </span>
+                    <br>
+                {% endfor %}
+                {% for slot in judge_slots %}
+                    {% if pairing.judges.all|length < slot %}
+                        <span class="unassigned" round-id="{{ pairing.id }}" judge-id="">
+                            <a class="btn-sm btn-light outround-judge-toggle dropdown-toggle"
+                               data-toggle="dropdown"
+                               href="#">N/A</a>
+                            <ul class="dropdown-menu">
+                            </ul>
+                        </span>
+                        <br>
+                    {% endif %}
+                {% endfor %}
+            </div>
+            <div class="col-3 text-center">
+                {% if pairing.victor == 1 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/outround/{{ pairing.id }}/result/">GOV win</a>
+                {% elif pairing.victor == 2 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/outround/{{ pairing.id }}/result/">OPP win</a>
+                {% elif pairing.victor == 3 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/outround/{{ pairing.id }}/result/">GOV via Forfeit</a>
+                {% elif pairing.victor == 4 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/outround/{{ pairing.id }}/result/">OPP via Forfeit</a>
+                {% else %}
+                    <a class="btn-sm btn-block btn-warning"
+                       href="/outround/{{ pairing.id }}/result/">Enter Ballot</a>
+                {% endif %}
+                <div class="dropdown room">
+                    <span room-id="{{ pairing.room.id }}"
+                          round-id="{{ pairing.id }}"
+                          outround="true">
+                        <a class="btn-sm btn-block btn-light room-toggle dropdown-toggle text-wrap"
+                           href="#"
+                           role="button"
+                           id="roomDropdown-{{ pairing.id }}"
+                           data-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"
+                           style="white-space: normal">
+                            <i class="far fa-building"></i> {{ pairing.room.name }}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="roomDropdown-{{ pairing.id }}"></div>
+                    </span>
+                </div>
+                <a class="btn-sm btn-block btn-light"
+                   href="/admin/tab/outround/{{ pairing.id }}/change/">
+                    <i class="fas fa-unlock-alt"></i> Edit in Admin
                 </a>
-                <small>
-                  <abbr title="Gov Team" class="attribute">GOV</abbr>
-
-                  <span class="team-assign-button"
-                    round-id={{pairing.id}}
-                    position="gov"
-                    team-id={{pairing.gov_team.id}}>
-                    <a class="dropdown-toggle outround-team-toggle text-dark"
-                        data-toggle="dropdown"
-                        href="#"
-                        title="Swap teams">
-                      <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu"></ul>
-                  </span>
-                  <br/>
-                  <a class="text-muted team outround-tabcard pt-1" team-id={{pairing.gov_team.id}}>
-                    Loading results...
-                  </a>
-                </small>
-              </h6>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <h6 class="opp-team">
-                <a href="/team/{{pairing.opp_team.id}}" class="team-link text-dark">
-                  {{pairing.opp_team.display_backend}}
-                </a>
-                <small>
-                  <abbr title="Opp Team" class="attribute">OPP</abbr>
-
-                  <span class="team-assign-button"
-                    round-id={{pairing.id}}
-                    position="opp"
-                    team-id={{pairing.opp_team.id}}>
-                    <a class="dropdown-toggle outround-team-toggle text-dark"
-                        data-toggle="dropdown"
-                        href="#"
-                        title="Swap teams">
-                      <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu"></ul>
-                  </span>
-
-                  <br/>
-                  <a class="text-muted team outround-tabcard pt-1"
-                      team-id={{pairing.opp_team.id}}>
-                    Loading results...
-                  </a>
-                </small>
-              </h6>
-
-            </td>
-          </tr>
-        </table>
-      </div>
-
-      <div class="col-4 judges">
-        {% for judge in pairing.judges.all %}
-        <span round-id="{{pairing.id}}" judge-id="{{judge.id}}">
-          <a class="btn-sm btn-light outround-judge-toggle dropdown-toggle{% if pairing.chair == judge %} chair{% endif %}"
-             data-toggle="dropdown" href="#">
-            {{judge.name}} <small>({{judge.rank}})</small>
-          </a>
-          <ul class="dropdown-menu"></ul>
-        </span>
-        <br>
-        {% endfor %}
-        {% for slot in judge_slots %}
-        {% if pairing.judges.all|length < slot %}
-        <span class="unassigned" round-id="{{pairing.id}}" judge-id="">
-          <a class="btn-sm btn-light outround-judge-toggle dropdown-toggle" data-toggle="dropdown" href="#">
-              N/A
-          </a>
-          <ul class="dropdown-menu"></ul>
-        </span>
-        <br>
-        {% endif %}
-        {% endfor %}
-      </div>
-
-      <div class="col-3 text-center">
-        {% if pairing.victor == 1 %}
-        <a class="btn-sm btn-block btn-success" href="/outround/{{pairing.id}}/result/">GOV win</a>
-        {% elif pairing.victor == 2 %}
-        <a class="btn-sm btn-block btn-success" href="/outround/{{pairing.id}}/result/">OPP win</a>
-        {% elif pairing.victor == 3 %}
-        <a class="btn-sm btn-block btn-success" href="/outround/{{pairing.id}}/result/">GOV via Forfeit</a>
-        {% elif pairing.victor == 4 %}
-        <a class="btn-sm btn-block btn-success" href="/outround/{{pairing.id}}/result/">OPP via Forfeit</a>
-        {% else %}
-        <a class="btn-sm btn-block btn-warning" href="/outround/{{pairing.id}}/result/">Enter Ballot</a>
-        {%endif%}
-        <div class="dropdown room">
-          <span 
-            room-id="{{pairing.room.id}}" 
-            round-id="{{pairing.id}}"
-            outround="true">
-            <a 
-              class="btn-sm btn-block btn-light room-toggle dropdown-toggle text-wrap" 
-              href="#" 
-              role="button" 
-              id="roomDropdown-{{pairing.id}}" 
-              data-toggle="dropdown" 
-              aria-haspopup="true" 
-              aria-expanded="false" 
-              style="white-space: normal;">
-              <i class="far fa-building"></i> {{pairing.room.name}}
-            </a>
-            <div class="dropdown-menu" aria-labelledby="roomDropdown-{{pairing.id}}"></div>
-          </span>
+                {% if choice %}
+                    <a class="btn-sm btn-block btn-success choice-update"
+                       href=""
+                       data-outround-id="{{ pairing.id }}">{{ pairing.get_choice_display }} choice</a>
+                {% endif %}
+            </div>
         </div>
-        <a class="btn-sm btn-block btn-light" href="/admin/tab/outround/{{pairing.id}}/change/">
-          <i class="fas fa-unlock-alt"></i> Edit in Admin
-        </a>
-	{% if choice %}
-    <a class="btn-sm btn-block btn-success choice-update" href="" data-outround-id="{{ pairing.id }}">
-      {{ pairing.get_choice_display }} choice
-    </a>
-	{% endif %}
-      </div>
     </div>
-    </div>
-  </div>
+</div>

--- a/mittab/templates/outrounds/pretty_pairing.html
+++ b/mittab/templates/outrounds/pretty_pairing.html
@@ -1,186 +1,168 @@
 <!DOCTYPE html>
-
-<html>
-<head>
-    {% load render_bundle from webpack_loader %}
-    {% render_bundle 'pairingDisplay' %}
-
-    <title>{{ label }}</title>
-
-    <style type="text/css">
-    </style>
-</head>
-
-<body class="show-team-names">
-    {% if printable %}
-        <!-- Center pairings table -->
-	{% for outround in outround_pairings %}
-	    <div style="padding: 20px;">
-		<center>{{ outround.label }}</center>
-		<table class="pairings_table printable">
-		    <tr>
-			<th>
-			    Government
-			</th> <th>
-			    Opposition
-			</th> <th>
-			    Judge
-			</th> <th>
-			    Room
-			</th>
-		    </tr>
-		    {% for pairing in outround.rounds %}
-			<tr>
-				<td>
-					<div class="team-names">
-						{{pairing.gov_team.display}}
-					</div>
-					{% if debater_team_memberships_public %}
-					<div class="member-names">
-						{{pairing.gov_team.debaters_display}}
-					</div>
-					{% endif %}
-				</td>
-				<td>
-					<div class="team-names">
-						{{pairing.opp_team.display}}
-					</div>
-					{% if debater_team_memberships_public %}
-					<div class="member-names">
-						{{pairing.opp_team.debaters_display}}
-					</div>
-					{% endif %}
-				</td>
-			    <td>
-				{% for judge in pairing.judges.all %}
-				    {% if pairing.judges.all|length > 1 and judge == pairing.chair %}
-					<b>{{judge.name}}</b><br>
-				    {% else %}
-					{{judge.name}}<br>
-				    {% endif %}
-				{% endfor %}
-			    </td>
-			    <td>{{pairing.room.name}}</td>
-			</tr>
-		    {% endfor %}
-		</table>
-	    </div>
-	{% empty %}
-	    Nothing is visible.
-	{% endfor %}
-    {% else %}
-        <div id="scrollPage" class="hidden"></div>
-        <!-- Floating top header -->
-        <div class="pairings_header">
-          <h1>{{ label }}</h1>
-          <!--<h3>({{team_count}} teams)</h3>-->
-
-          <table class="pairings_table">
-              <tr>
-              <th>
-                  {% if gov_opp_display %}Government{% else %}Team 1{% endif %}
-              </th> <th>
-                  {% if gov_opp_display %}Opposition{% else %}Team 2{% endif %}
-              </th> <th>
-                  Judge
-              </th> <th>
-                  Room
-              </th>
-              </tr>
-          </table>
-        </div>
-	
-        <div class="pairings_header_spacer"></div>
-	
-        <!-- Center pairings table -->
-	{% for outround in outround_pairings %}
-	    <center><h4><b>{{ outround.label }}</b></h4></center>
-	    <table class="pairings_table">		    
-		{% for pairing in outround.rounds %}
-		    
-		    <tr>
-			<td>
-			    {% if sidelock and pairing.sidelock %}<b>{% endif %}
-			    {% if choice and pairing.choice == 1 %}<b>{% endif %}
-				<div class="team-names">
-					{{pairing.gov_team.display}}
-				</div>
-				{% if debater_team_memberships_public %}
-				<div class="member-names">
-					{{pairing.gov_team.debaters_display}}
-				</div>
-				{% endif %}
-			    {% if choice and pairing.choice == 1 %}</b>{% endif %}
-			    {% if sidelock and pairing.sidelock %}</b>{% endif %}
-			</td>
-			<td>
-			    {% if choice and pairing.choice == 2 %}<b>{% endif %}
-				<div class="team-names">
-					{{pairing.opp_team.display}}
-				</div>
-				{% if debater_team_memberships_public %}
-				<div class="member-names">
-					{{pairing.opp_team.debaters_display}}
-				</div>
-				{% endif %}
-			    {% if choice and pairing.choice == 2 %}</b>{% endif %}
-			</td>
-			<td>
-			    {% for judge in pairing.judges.all %}
-				{% if pairing.judges.all|length > 1 and judge == pairing.chair %}
-				    <b>{{judge.name}}</b><br>
-				{% else %}
-				    {{judge.name}}<br>
-				{% endif %}
-			    {% endfor %}
-			</td>
-			<td>{{pairing.room.name}}</td>
-		    </tr>
-		{% endfor %}
-		{% if outround.excluded|length > 0 %}
-		    <tr>
-			<td><b>Advancing Teams:</b></td>
-			<td colspan="3">
-			    {% for team in outround.excluded %}
-				{{ team.display }}{% if not forloop.last %}, {% endif %}
-			    {% endfor %}
-			</td>
-		    </tr>
-		{% endif %}
-	    </table>
-	{% empty %}
-	    <div style="padding: 20px;">Nothing is visible.</div>
-	{% endfor %}
-        <div class="pairings_footer_spacer"></div>
-        <!-- Floating bottom header -->
-        <div class="pairings_footer">
-	    {% if sidelock %}
-		<span class="left">
-		    * Bold indicates sidelock.
-		</span>
-	    {% endif %}
-	    {% if choice %}
-		<span class="left">
-		    * Bold indicates choice.
-	    {% endif %}
-		{% if debater_team_memberships_public %}
-		<span class="right">
-		<label for="Member Names">
-			Member Names:
-			<input type="checkbox" name="names" id="name_display_toggle"/>
-		</label>
-		</span>
-	    {% endif %}
-	    <span class="right">
-		<label for="autoscroll">
-		    Autoscroll:
-		    <input type="checkbox" name="autoscroll" id="autoscroll" checked/>
-		</label>
-	    </span>
-        </div>
-    {% endif %}
-
-</body>
-
-</html>
-
+<html lang="en">
+    <head>
+        {% load render_bundle from webpack_loader %}
+        {% render_bundle 'pairingDisplay' %}
+        <title>{{ label }}</title>
+        <style type="text/css"></style>
+    </head>
+    <body class="show-team-names">
+        {% if printable %}
+            <!-- Center pairings table -->
+            {% for outround in outround_pairings %}
+                <div style="padding: 20px;">
+                    <center>{{ outround.label }}</center>
+                    <table class="pairings_table printable">
+                        <tr>
+                            <th>Government</th>
+                            <th>Opposition</th>
+                            <th>Judge</th>
+                            <th>Room</th>
+                        </tr>
+                        {% for pairing in outround.rounds %}
+                            <tr>
+                                <td>
+                                    <div class="team-names">{{ pairing.gov_team.display }}</div>
+                                    {% if debater_team_memberships_public %}
+                                        <div class="member-names">{{ pairing.gov_team.debaters_display }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <div class="team-names">{{ pairing.opp_team.display }}</div>
+                                    {% if debater_team_memberships_public %}
+                                        <div class="member-names">{{ pairing.opp_team.debaters_display }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% for judge in pairing.judges.all %}
+                                        {% if pairing.judges.all|length > 1 and judge == pairing.chair %}
+                                            <b>{{ judge.name }}</b>
+                                            <br>
+                                        {% else %}
+                                            {{ judge.name }}
+                                            <br>
+                                        {% endif %}
+                                    {% endfor %}
+                                </td>
+                                <td>{{ pairing.room.name }}</td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            {% empty %}
+                Nothing is visible.
+            {% endfor %}
+        {% else %}
+            <div id="scrollPage" class="hidden"></div>
+            <!-- Floating top header -->
+            <div class="pairings_header">
+                <h1>{{ label }}</h1>
+                <!--<h3>({{team_count}} teams)</h3>-->
+                <table class="pairings_table">
+                    <tr>
+                        <th>
+                            {% if gov_opp_display %}
+                                Government
+                            {% else %}
+                                Team 1
+                            {% endif %}
+                        </th>
+                        <th>
+                            {% if gov_opp_display %}
+                                Opposition
+                            {% else %}
+                                Team 2
+                            {% endif %}
+                        </th>
+                        <th>Judge</th>
+                        <th>Room</th>
+                    </tr>
+                </table>
+            </div>
+            <div class="pairings_header_spacer"></div>
+            <!-- Center pairings table -->
+            {% for outround in outround_pairings %}
+                <center>
+                    <h4>
+                        <b>{{ outround.label }}</b>
+                    </h4>
+                </center>
+                <table class="pairings_table">
+                    {% for pairing in outround.rounds %}
+                        <tr>
+                            <td>
+                                {% if sidelock and pairing.sidelock %}<b>{% endif %}
+                                    {% if choice and pairing.choice == 1 %}<b>{% endif %}
+                                        <div class="team-names">{{ pairing.gov_team.display }}</div>
+                                        {% if debater_team_memberships_public %}
+                                            <div class="member-names">{{ pairing.gov_team.debaters_display }}</div>
+                                        {% endif %}
+                                        {% if choice and pairing.choice == 1 %}</b>{% endif %}
+                                    {% if sidelock and pairing.sidelock %}</b>{% endif %}
+                            </td>
+                            <td>
+                                {% if choice and pairing.choice == 2 %}<b>{% endif %}
+                                    <div class="team-names">{{ pairing.opp_team.display }}</div>
+                                    {% if debater_team_memberships_public %}
+                                        <div class="member-names">{{ pairing.opp_team.debaters_display }}</div>
+                                    {% endif %}
+                                    {% if choice and pairing.choice == 2 %}</b>{% endif %}
+                            </td>
+                            <td>
+                                {% for judge in pairing.judges.all %}
+                                    {% if pairing.judges.all|length > 1 and judge == pairing.chair %}
+                                        <b>{{ judge.name }}</b>
+                                        <br>
+                                    {% else %}
+                                        {{ judge.name }}
+                                        <br>
+                                    {% endif %}
+                                {% endfor %}
+                            </td>
+                            <td>{{ pairing.room.name }}</td>
+                        </tr>
+                    {% endfor %}
+                    {% if outround.excluded|length > 0 %}
+                        <tr>
+                            <td>
+                                <b>Advancing Teams:</b>
+                            </td>
+                            <td colspan="3">
+                                {% for team in outround.excluded %}
+                                    {{ team.display }}
+                                    {% if not forloop.last %},{% endif %}
+                                {% endfor %}
+                            </td>
+                        </tr>
+                    {% endif %}
+                </table>
+            {% empty %}
+                <div style="padding: 20px;">Nothing is visible.</div>
+            {% endfor %}
+            <div class="pairings_footer_spacer"></div>
+            <!-- Floating bottom header -->
+            <div class="pairings_footer">
+                {% if sidelock %}<span class="left">* Bold indicates sidelock.</span>{% endif %}
+                {% if choice %}
+                    <span class="left">
+                        * Bold indicates choice.
+                    </span>
+                    {% endif %}
+                    {% if debater_team_memberships_public %}
+                        <span class="right">
+                            <label for="Member Names">
+                                Member Names:
+                                <input type="checkbox" name="names" id="name_display_toggle" />
+                            </label>
+                        </span>
+                    {% endif %}
+                    <span class="right">
+                        <label for="autoscroll">
+                            Autoscroll:
+                            <input type="checkbox" name="autoscroll" id="autoscroll" checked />
+                        </label>
+                    </span>
+                </div>
+            {% endif %}
+        </body>
+    </html>

--- a/mittab/templates/pairing/_pairing_card.html
+++ b/mittab/templates/pairing/_pairing_card.html
@@ -1,139 +1,137 @@
 <div class="card bg-light pairing-card mb-3">
-  <div class="card-body container-fluid">
-    <div class="row" round-id="{{pairing.id}}">
-
-      <div class="col-5">
-        <table class="table table-borderless table-sm mb-0 team-table">
-          <tr>
-            <td>
-              <h6 class="gov-team">
-                <a href="/team/{{pairing.gov_team.id}}" class="text-dark team-link">
-                  {{pairing.gov_team.display_backend}}
+    <div class="card-body container-fluid">
+        <div class="row" round-id="{{ pairing.id }}">
+            <div class="col-5">
+                <table class="table table-borderless table-sm mb-0 team-table">
+                    <tr>
+                        <td>
+                            <h6 class="gov-team">
+                                <a href="/team/{{ pairing.gov_team.id }}" class="text-dark team-link">{{ pairing.gov_team.display_backend }}</a>
+                                <small>
+                                    <abbr title="Gov Team" class="attribute">GOV</abbr>
+                                    <span class="team-assign-button"
+                                          round-id="{{ pairing.id }}"
+                                          position="gov"
+                                          team-id="{{ pairing.gov_team.id }}">
+                                        <a class="dropdown-toggle team-toggle text-dark"
+                                           data-toggle="dropdown"
+                                           href="#"
+                                           title="Swap teams">
+                                            <span class="caret"></span>
+                                        </a>
+                                        <ul class="dropdown-menu">
+                                        </ul>
+                                    </span>
+                                    <br />
+                                    <a class="text-muted team tabcard pt-1"
+                                       team-id="{{ pairing.gov_team.id }}">Loading results...</a>
+                                </small>
+                            </h6>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <h6 class="opp-team">
+                                <a href="/team/{{ pairing.opp_team.id }}" class="team-link text-dark">{{ pairing.opp_team.display_backend }}</a>
+                                <small>
+                                    <abbr title="Opp Team" class="attribute">OPP</abbr>
+                                    <span class="team-assign-button"
+                                          round-id="{{ pairing.id }}"
+                                          position="opp"
+                                          team-id="{{ pairing.opp_team.id }}">
+                                        <a class="dropdown-toggle team-toggle text-dark"
+                                           data-toggle="dropdown"
+                                           href="#"
+                                           title="Swap teams">
+                                            <span class="caret"></span>
+                                        </a>
+                                        <ul class="dropdown-menu">
+                                        </ul>
+                                    </span>
+                                    <br />
+                                    <a class="text-muted team tabcard pt-1"
+                                       team-id="{{ pairing.opp_team.id }}">Loading results...</a>
+                                </small>
+                            </h6>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="col-4 judges">
+                {% for judge in pairing.judges.all %}
+                    <span round-id="{{ pairing.id }}" judge-id="{{ judge.id }}">
+                        <a class="btn-sm btn-light judge-toggle dropdown-toggle{% if pairing.chair == judge %} chair{% endif %}"
+                           data-toggle="dropdown"
+                           href="#">
+                            {{ judge.name }} <small>({{ judge.rank }})</small>
+                        </a>
+                        <ul class="dropdown-menu">
+                        </ul>
+                    </span>
+                    <br>
+                {% endfor %}
+                {% for slot in judge_slots %}
+                    {% if pairing.judges.all|length < slot %}
+                        <span class="unassigned" round-id="{{ pairing.id }}" judge-id="">
+                            <a class="btn-sm btn-light judge-toggle dropdown-toggle"
+                               data-toggle="dropdown"
+                               href="#">N/A</a>
+                            <ul class="dropdown-menu">
+                            </ul>
+                        </span>
+                        <br>
+                    {% endif %}
+                {% endfor %}
+            </div>
+            <div class="col-3 text-center">
+                {% if pairing.victor == 1 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/round/{{ pairing.id }}/result/">GOV win</a>
+                {% elif pairing.victor == 2 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/round/{{ pairing.id }}/result/">OPP win</a>
+                {% elif pairing.victor == 3 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/round/{{ pairing.id }}/result/">GOV via Forfeit</a>
+                {% elif pairing.victor == 4 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/round/{{ pairing.id }}/result/">OPP via Forfeit</a>
+                {% elif pairing.victor == 5 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/round/{{ pairing.id }}/result/">All Drop</a>
+                {% elif pairing.victor == 6 %}
+                    <a class="btn-sm btn-block btn-success"
+                       href="/round/{{ pairing.id }}/result/">All Win</a>
+                {% else %}
+                    <a class="btn-sm btn-block btn-warning"
+                       href="/round/{{ pairing.id }}/result/">Enter Ballot</a>
+                {% endif %}
+                {% if pairing.judges.all|length > 1 %}
+                    <a class="btn-sm btn-block btn-warning"
+                       href="/round/{{ pairing.id }}/result/{{ pairing.judges.all|length }}/">Enter Panel</a>
+                {% endif %}
+                <div class="dropdown room">
+                    <span room-id="{{ pairing.room.id }}"
+                          round-id="{{ pairing.id }}"
+                          outround="false">
+                        <a class="btn-sm btn-block btn-light room-toggle dropdown-toggle text-wrap"
+                           href="#"
+                           role="button"
+                           id="roomDropdown-{{ pairing.id }}"
+                           data-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"
+                           style="white-space: normal">
+                            <i class="far fa-building"></i> {{ pairing.room.name }}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="roomDropdown-{{ pairing.id }}"></div>
+                    </span>
+                </div>
+                <a class="btn-sm btn-block btn-light"
+                   href="/admin/tab/round/{{ pairing.id }}/change/">
+                    <i class="fas fa-unlock-alt"></i> Edit in Admin
                 </a>
-                <small>
-                  <abbr title="Gov Team" class="attribute">GOV</abbr>
-
-                  <span class="team-assign-button"
-                    round-id={{pairing.id}}
-                    position="gov"
-                    team-id={{pairing.gov_team.id}}>
-                    <a class="dropdown-toggle team-toggle text-dark"
-                        data-toggle="dropdown"
-                        href="#"
-                        title="Swap teams">
-                      <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu"></ul>
-                  </span>
-                  <br/>
-                  <a class="text-muted team tabcard pt-1" team-id={{pairing.gov_team.id}}>
-                    Loading results...
-                  </a>
-                </small>
-              </h6>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <h6 class="opp-team">
-                <a href="/team/{{pairing.opp_team.id}}" class="team-link text-dark">
-                  {{pairing.opp_team.display_backend}}
-                </a>
-                <small>
-                  <abbr title="Opp Team" class="attribute">OPP</abbr>
-
-                  <span class="team-assign-button"
-                    round-id={{pairing.id}}
-                    position="opp"
-                    team-id={{pairing.opp_team.id}}>
-                    <a class="dropdown-toggle team-toggle text-dark"
-                        data-toggle="dropdown"
-                        href="#"
-                        title="Swap teams">
-                      <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu"></ul>
-                  </span>
-
-                  <br/>
-                  <a class="text-muted team tabcard pt-1"
-                      team-id={{pairing.opp_team.id}}>
-                    Loading results...
-                  </a>
-                </small>
-              </h6>
-
-            </td>
-          </tr>
-        </table>
-      </div>
-
-      <div class="col-4 judges">
-        {% for judge in pairing.judges.all %}
-        <span round-id="{{pairing.id}}" judge-id="{{judge.id}}">
-          <a class="btn-sm btn-light judge-toggle dropdown-toggle{% if pairing.chair == judge %} chair{% endif %}"
-             data-toggle="dropdown" href="#">
-            {{judge.name}} <small>({{judge.rank}})</small>
-          </a>
-          <ul class="dropdown-menu"></ul>
-        </span>
-        <br>
-        {% endfor %}
-        {% for slot in judge_slots %}
-        {% if pairing.judges.all|length < slot %}
-        <span class="unassigned" round-id="{{pairing.id}}" judge-id="">
-          <a class="btn-sm btn-light judge-toggle dropdown-toggle" data-toggle="dropdown" href="#">
-              N/A
-          </a>
-          <ul class="dropdown-menu"></ul>
-        </span>
-        <br>
-        {% endif %}
-        {% endfor %}
-      </div>
-
-      <div class="col-3 text-center">
-        {% if pairing.victor == 1 %}
-        <a class="btn-sm btn-block btn-success" href="/round/{{pairing.id}}/result/">GOV win</a>
-        {% elif pairing.victor == 2 %} 
-        <a class="btn-sm btn-block btn-success" href="/round/{{pairing.id}}/result/">OPP win</a>
-        {% elif pairing.victor == 3 %}
-        <a class="btn-sm btn-block btn-success" href="/round/{{pairing.id}}/result/">GOV via Forfeit</a>
-        {% elif pairing.victor == 4 %}
-        <a class="btn-sm btn-block btn-success" href="/round/{{pairing.id}}/result/">OPP via Forfeit</a>
-        {% elif pairing.victor == 5 %}
-        <a class="btn-sm btn-block btn-success" href="/round/{{pairing.id}}/result/">All Drop</a>
-        {% elif pairing.victor == 6 %}
-        <a class="btn-sm btn-block btn-success" href="/round/{{pairing.id}}/result/">All Win</a>
-        {% else %}
-        <a class="btn-sm btn-block btn-warning" href="/round/{{pairing.id}}/result/">Enter Ballot</a>
-        {%endif%}
-        {% if pairing.judges.all|length > 1 %}
-        <a class="btn-sm btn-block btn-warning" href="/round/{{pairing.id}}/result/{{pairing.judges.all|length}}/">Enter Panel</a>
-        {% endif %}
-        <div class="dropdown room">
-          <span 
-            room-id="{{pairing.room.id}}" 
-            round-id="{{pairing.id}}"
-            outround="false">
-            <a 
-              class="btn-sm btn-block btn-light room-toggle dropdown-toggle text-wrap" 
-              href="#" 
-              role="button" 
-              id="roomDropdown-{{pairing.id}}" 
-              data-toggle="dropdown" 
-              aria-haspopup="true" 
-              aria-expanded="false" 
-              style="white-space: normal;">
-              <i class="far fa-building"></i> {{pairing.room.name}}
-            </a>
-            <div class="dropdown-menu" aria-labelledby="roomDropdown-{{pairing.id}}"></div>
-          </span>
+            </div>
         </div>
-        <a class="btn-sm btn-block btn-light" href="/admin/tab/round/{{pairing.id}}/change/">
-          <i class="fas fa-unlock-alt"></i> Edit in Admin
-        </a>
-      </div>
     </div>
-    </div>
-  </div>
+</div>

--- a/mittab/templates/pairing/judge_dropdown.html
+++ b/mittab/templates/pairing/judge_dropdown.html
@@ -1,46 +1,44 @@
-
 {% if current_judge_id %}
-<h6 class="text-center dropdown-header">Options</h6>
-
-<a href="#" class="btn btn-danger btn-sm dropdown-item {% if is_outround %}outround-judge-remove{% else %}judge-remove{% endif %}" round-id="{{round_obj.id}}" judge-id="{{current_judge_id}}">
-  Remove Judge
-</a>
-
-{% if current_judge_id != round_obj.chair.id %}
-<a href="#" class="btn btn-primary btn-sm dropdown-item {% if is_outround %}outround-judge-chair{% else %}judge-chair{% endif %}" round-id="{{round_obj.id}}" judge-id="{{current_judge_id}}">
-  Set To Chair
-</a>
+    <h6 class="text-center dropdown-header">Options</h6>
+    <a href="#"
+       class="btn btn-danger btn-sm dropdown-item {% if is_outround %}outround-judge-remove{% else %}judge-remove{% endif %}"
+       round-id="{{ round_obj.id }}"
+       judge-id="{{ current_judge_id }}">Remove Judge</a>
+    {% if current_judge_id != round_obj.chair.id %}
+        <a href="#"
+           class="btn btn-primary btn-sm dropdown-item {% if is_outround %}outround-judge-chair{% else %}judge-chair{% endif %}"
+           round-id="{{ round_obj.id }}"
+           judge-id="{{ current_judge_id }}">Set To Chair</a>
+    {% endif %}
+    <div class="dropdown-divider"></div>
 {% endif %}
-
-<div class="dropdown-divider"></div>
-{% endif %}
-
 <div class="form-group pl-2 pt-2 mb-1">
-  <input id="quick-search"
-        class="form-control form-control-sm" type="text" placeholder="Search...">
+    <input id="quick-search"
+           class="form-control form-control-sm"
+           type="text"
+           placeholder="Search...">
 </div>
-
 <h6 class="text-center dropdown-header">Current Judge</h6>
-
-<a class="dropdown-item "href="/judge/{{current_judge_id}}">
-  {{current_judge_name}} - {{current_judge_rank}}
-</a>
+<a class="dropdown-item "href="/judge/{{ current_judge_id }}">{{ current_judge_name }} - {{ current_judge_rank }}</a>
 <div class="dropdown-divider"></div>
 <h6 class="text-center dropdown-header">Viable Judges Not Paired In</h6>
-{% for judge_name, judge_id, judge_rank in excluded_judges%}
-<a href="#" class="dropdown-item judge-assign searchable" judge-id="{{judge_id}}" round-id="{{round_obj.id}}" current-judge-id="{{current_judge_id}}">
-  {{judge_name}} - {{judge_rank}}
-</a>
+{% for judge_name, judge_id, judge_rank in excluded_judges %}
+    <a href="#"
+       class="dropdown-item judge-assign searchable"
+       judge-id="{{ judge_id }}"
+       round-id="{{ round_obj.id }}"
+       current-judge-id="{{ current_judge_id }}">{{ judge_name }} - {{ judge_rank }}</a>
 {% empty %}
-<a class="dropdown-item">No viable judges</a>
+    <a class="dropdown-item">No viable judges</a>
 {% endfor %}
-
 <div class="dropdown-divider"></div>
 <h6 class="text-center dropdown-header">Viable Judges Within Pairing</h6>
-{% for judge_name, judge_id, judge_rank in included_judges%}
-<a href="#" class="dropdown-item judge-assign searchable" judge-id="{{judge_id}}" round-id="{{round_obj.id}}" current-judge-id="{{current_judge_id}}">
-  {{judge_name}} - {{judge_rank}}
-</a>
+{% for judge_name, judge_id, judge_rank in included_judges %}
+    <a href="#"
+       class="dropdown-item judge-assign searchable"
+       judge-id="{{ judge_id }}"
+       round-id="{{ round_obj.id }}"
+       current-judge-id="{{ current_judge_id }}">{{ judge_name }} - {{ judge_rank }}</a>
 {% empty %}
-<a class="dropdown-item">No viable judges</a>
+    <a class="dropdown-item">No viable judges</a>
 {% endfor %}

--- a/mittab/templates/pairing/pair_round.html
+++ b/mittab/templates/pairing/pair_round.html
@@ -1,32 +1,34 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}{{ title }}{% endblock %}
-
+{% block title %}
+    {{ title }}
+{% endblock title %}
 {% block content %}
-
-<div class="col-2"></div>
-<div id="pairing_form" class="col-8">
-  <h3 class="text-center mb-4">{{ title }}</h3>
-  <form action="." method="post"> {% csrf_token %}
-    <table class="check_status table">
-      <thead class="thead-dark">
-        <th>Sanity Check</th><th>Successful?</th>
-      </thead>
-      {% for check,status,alt in check_status%}
-      <tr class="table-{% if status == "No" %}danger font-weight-bolder{% else %}light{% endif %}">
-        <td>{{check}}</td>
-        <td title="{{alt}}">{{status}}</td>
-      </tr>
-      {% endfor %}
-    </table>
-    <div class="mt-5">
-      <p class="alert alert-warning">
-        This action will attempt to pair the next round. If you have ignored the warnings above it may fail. Be warned, and always backup if you are unsure.
-      </p>
-      <input class="btn btn-primary btn-block btn-lg" type="submit" value="Pair This Round">
+    <div class="col-2"></div>
+    <div id="pairing_form" class="col-8">
+        <h3 class="text-center mb-4">{{ title }}</h3>
+        <form action="." method="post">
+            {% csrf_token %}
+            <table class="check_status table">
+                <thead class="thead-dark">
+                    <th>Sanity Check</th>
+                    <th>Successful?</th>
+                </thead>
+                {% for check,status,alt in check_status %}
+                    <tr class="table-{% if status == "No" %}danger font-weight-bolder{% else %}light{% endif %}">
+                        <td>{{ check }}</td>
+                        <td title="{{ alt }}">{{ status }}</td>
+                    </tr>
+                {% endfor %}
+            </table>
+            <div class="mt-5">
+                <p class="alert alert-warning">
+                    This action will attempt to pair the next round. If you have ignored the warnings above it may fail. Be warned, and always backup if you are unsure.
+                </p>
+                <input class="btn btn-primary btn-block btn-lg"
+                       type="submit"
+                       value="Pair This Round">
+            </div>
+        </form>
     </div>
-  </form>
-</div>
-<div class="col-2"></div>
-
-{% endblock %}
+    <div class="col-2"></div>
+{% endblock content %}

--- a/mittab/templates/pairing/pairing_control.html
+++ b/mittab/templates/pairing/pairing_control.html
@@ -1,171 +1,191 @@
 {% extends "base/__wide.html" %}
-
-{% block title %}Round Status{% endblock %}
-
+{% block title %}
+    Round Status
+{% endblock title %}
 {% block content %}
-<div id="round-number" data-round-number={{ round_number }} style="display: none;"></div>
-
-<div class="col">
-  <div class="containter">
-    <div class="row">
-      <div class="col">
-        <h3>
-          Round Status for Round {{round_number}}:
-          <small class="{% if not errors or num_excluded == 0 %}text-success{% else %}text-danger{% endif %}">
-            {% if not errors or num_excluded == 0 %} Valid {% else %} Invalid {% endif %} pairing
-          </small>
-        </h3>
-      </div>
-    </div> <!-- end heading row -->
-
-
-    <div class="row mb-3">
-      <div class="col-8">
-        <h6>Pairing Controls</h6>
-
-          <form action="/pairing/assign_judges/"
-            method="post"
-            onsubmit="return confirm('Do you really want to assign judges. All previous assignments will be lost.  If you are unsure, click cancel and back up')"
-            class="d-inline"
-          >
-            {% csrf_token %}
-            {% if judges_assigned %}
-            <button id="assign-judges" type="submit" class="mid btn btn-sm btn-success" href="/pairing/assign_judges/" title="Assign judges to your pairing">
-              <i class="fas fa-gavel"></i> Assign Judges Again
-            </button>
-            {% else %}
-            <button id="assign-judges" type="submit" class="mid btn btn-sm btn-warning" href="/pairing/assign_judges/" title="Assign judges to your pairing">
-              <i class="fas fa-gavel"></i> Assign Judges
-            </button>
-            {% endif %}
-          </form>
-
-          <form action="/pairing/assign_rooms_to_pairing/" method="post" 
-            onsubmit="return confirm('Do you really want to assign rooms? All previous assignments will be lost. If you are unsure, click cancel and back up')" 
-            class="d-inline"
-          >
-            {% csrf_token %}
-
-            {% if rooms_assigned %}
-            <button id="assign-rooms" type="submit" class="mid btn btn-sm btn-success" title="Assign rooms to your pairing">
-              <i class="fas fa-chalkboard-teacher"></i> Assign Rooms Again
-            </button>
-            {% else %}
-            <button id="assign-rooms" type="submit" class="mid btn btn-sm btn-warning" title="Assign rooms to your pairing">
-              <i class="fas fa-chalkboard-teacher"></i> Assign Rooms
-            </button>
-            {% endif %}
-          </form>
-
-          {% if simulate_round_button %}
-          <form action="/pairings/simulate_rounds/" method="post" class="d-inline"> 
-            {% csrf_token %}
-            <button id="simulate-round" type="submit" class="btn btn-sm btn-primary" title="Simulate the round">
-              <i class="fas fa-play"></i> Simulate Round
-            </button>
-          </form>
-          {% endif %}
-
-          <a class="btn btn-sm btn-success release {% if not pairing_released %}d-none{% endif %}" href="#"
-              id="close-pairings"
-              title="Release the pairings to the participants">
-            <i class="fas fa-door-closed"></i> Close Pairings
-          </a>
-
-          <a class="btn btn-sm btn-warning release {% if pairing_released %}d-none{% endif %}" href="#"
-              id="release-pairings"
-              title="Release the pairings to the participants">
-            <i class="fas fa-door-open"></i> Release Pairings
-          </a>
-
-          {% if round_number == tot_rounds %}
-          <a class="btn btn-sm btn-info" href="{% url "break" %}" title="Break 'em">
-            <i class="fas fa-arrow-right"></i> Break 'em
-          </a>
-          {% else %}
-          <a class="btn btn-sm btn-info" href="/pairing/pair_round" title="Pair the next round of debate">
-            <i class="fas fa-arrow-right"></i> Prepare Next Round
-          </a>
-          {% endif %}
+    <div id="round-number"
+         data-round-number="{{ round_number }}"
+         style="display: none"></div>
+    <div class="col">
+        <div class="containter">
+            <div class="row">
+                <div class="col">
+                    <h3>
+                        Round Status for Round {{ round_number }}:
+                        <small class="{% if not errors or num_excluded == 0 %}text-success{% else %}text-danger{% endif %}">
+                            {% if not errors or num_excluded == 0 %}
+                                Valid
+                            {% else %}
+                                Invalid
+                            {% endif %}
+                            pairing
+                        </small>
+                    </h3>
+                </div>
+            </div>
+            <!-- end heading row -->
+            <div class="row mb-3">
+                <div class="col-8">
+                    <h6>Pairing Controls</h6>
+                    <form action="/pairing/assign_judges/"
+                          method="post"
+                          onsubmit="return confirm('Do you really want to assign judges. All previous assignments will be lost.  If you are unsure, click cancel and back up')"
+                          class="d-inline">
+                        {% csrf_token %}
+                        {% if judges_assigned %}
+                            <button id="assign-judges"
+                                    type="submit"
+                                    class="mid btn btn-sm btn-success"
+                                    href="/pairing/assign_judges/"
+                                    title="Assign judges to your pairing">
+                                <i class="fas fa-gavel"></i> Assign Judges Again
+                            </button>
+                        {% else %}
+                            <button id="assign-judges"
+                                    type="submit"
+                                    class="mid btn btn-sm btn-warning"
+                                    href="/pairing/assign_judges/"
+                                    title="Assign judges to your pairing">
+                                <i class="fas fa-gavel"></i> Assign Judges
+                            </button>
+                        {% endif %}
+                    </form>
+                    <form action="/pairing/assign_rooms_to_pairing/"
+                          method="post"
+                          onsubmit="return confirm('Do you really want to assign rooms? All previous assignments will be lost. If you are unsure, click cancel and back up')"
+                          class="d-inline">
+                        {% csrf_token %}
+                        {% if rooms_assigned %}
+                            <button id="assign-rooms"
+                                    type="submit"
+                                    class="mid btn btn-sm btn-success"
+                                    title="Assign rooms to your pairing">
+                                <i class="fas fa-chalkboard-teacher"></i> Assign Rooms Again
+                            </button>
+                        {% else %}
+                            <button id="assign-rooms"
+                                    type="submit"
+                                    class="mid btn btn-sm btn-warning"
+                                    title="Assign rooms to your pairing">
+                                <i class="fas fa-chalkboard-teacher"></i> Assign Rooms
+                            </button>
+                        {% endif %}
+                    </form>
+                    {% if simulate_round_button %}
+                        <form action="/pairings/simulate_rounds/" method="post" class="d-inline">
+                            {% csrf_token %}
+                            <button id="simulate-round"
+                                    type="submit"
+                                    class="btn btn-sm btn-primary"
+                                    title="Simulate the round">
+                                <i class="fas fa-play"></i> Simulate Round
+                            </button>
+                        </form>
+                    {% endif %}
+                    <a class="btn btn-sm btn-success release {% if not pairing_released %}d-none{% endif %}"
+                       href="#"
+                       id="close-pairings"
+                       title="Release the pairings to the participants">
+                        <i class="fas fa-door-closed"></i> Close Pairings
+                    </a>
+                    <a class="btn btn-sm btn-warning release {% if pairing_released %}d-none{% endif %}"
+                       href="#"
+                       id="release-pairings"
+                       title="Release the pairings to the participants">
+                        <i class="fas fa-door-open"></i> Release Pairings
+                    </a>
+                    {% if round_number == tot_rounds %}
+                        <a class="btn btn-sm btn-info"
+                           href="{% url "break" %}"
+                           title="Break 'em">
+                            <i class="fas fa-arrow-right"></i> Break 'em
+                        </a>
+                    {% else %}
+                        <a class="btn btn-sm btn-info"
+                           href="/pairing/pair_round"
+                           title="Pair the next round of debate">
+                            <i class="fas fa-arrow-right"></i> Prepare Next Round
+                        </a>
+                    {% endif %}
+                </div>
+                <div class="col-4">
+                    <h6>Display Options</h6>
+                    <div class="btn-group btn-group-sm">
+                        <a class="btn btn-secondary"
+                           href="/pairings/pairinglist/"
+                           title="To display in GA">
+                            <i class="fas fa-tv"></i> Announcement View
+                        </a>
+                        <a class="btn btn-secondary"
+                           href="/pairings/pairinglist/printable"
+                           title="Printable version of the GA view">
+                            <i class="fas fa-print"></i> Printable View
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <!-- end control row -->
+            <div class="row">
+                <div class="col-12">
+                    {% if errors %}
+                        {% for error in errors %}<div class="alert alert-danger">{{ error }}</div>{% endfor %}
+                    {% endif %}
+                    {% if num_excluded > 0 %}
+                        <div class="alert alert-danger">
+                            {{ num_excluded }} teams are checked-in but have no round or bye.
+                            <button class="btn btn-small btn-link"
+                                    data-toggle="collapse"
+                                    data-target="#excluded_teams_no_bye">Show/Hide</button>
+                            <div id="excluded_teams_no_bye" class="collapse">
+                                {% for team in excluded_teams_no_bye %}
+                                    {{ team.name }}
+                                    <br>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+            <!-- end alert row -->
+            <div class="row">
+                {% for pairing in round_info %}
+                    <div class="col-xl-6">{% include "pairing/_pairing_card.html" %}</div>
+                {% endfor %}
+            </div>
+            <!-- end pairings row -->
+            <div class="row mt-2 mb-2">
+                <div class="col not-paired-in overflow-auto border-bottom">
+                    <h5>People Not Paired In</h5>
+                    <table class="table table-striped table-sm">
+                        <thead>
+                            <th>Checked in Teams ({{ excluded_teams|length }})</th>
+                            <th>Checked in Judges ({{ excluded_judges|length }})</th>
+                            <th>Non Checked in Judges ({{ non_checkins|length }})</th>
+                            <th>Available Rooms ({{ available_rooms|length }})</th>
+                        </thead>
+                        {% for team, cjudge, judge, room in excluded_people %}
+                            <tr>
+                                <td>
+                                    {% if team %}<a href="/team/{{ team.id }}">{{ team.name }}</a>{% endif %}
+                                </td>
+                                <td>
+                                    {% if cjudge %}<a href="/judge/{{ cjudge.id }}">{{ cjudge.name }}</a>{% endif %}
+                                </td>
+                                <td>
+                                    {% if judge %}
+                                        <a class="{% if judge.rank > warning %}text-danger{% endif %}"
+                                           href="/judge/{{ judge.id }}">{{ judge.name }}</a>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if room %}<a href="/room/{{ room.id }}">{{ room.name }}</a>{% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            </div>
+            <!-- end not-paired-in row -->
         </div>
-
-      <div class="col-4">
-        <h6>Display Options</h6>
-
-        <div class="btn-group btn-group-sm">
-          <a class="btn btn-secondary" href="/pairings/pairinglist/" title="To display in GA">
-            <i class="fas fa-tv"></i> Announcement View
-          </a>
-
-          <a class="btn btn-secondary" href="/pairings/pairinglist/printable" title="Printable version of the GA view">
-            <i class="fas fa-print"></i> Printable View
-          </a>
-        </div>
-      </div>
-    </div> <!-- end control row -->
-
-    <div class="row">
-      <div class="col-12">
-        {% if errors %}
-        {% for error in errors %}
-        <div class="alert alert-danger">{{ error }}</div>
-        {% endfor %}
-        {% endif %}
-
-        {% if num_excluded > 0 %}
-        <div class="alert alert-danger">
-          {{ num_excluded }} teams are checked-in but have no round or bye.
-
-          <button class="btn btn-small btn-link" data-toggle="collapse" data-target="#excluded_teams_no_bye">Show/Hide</button>
-
-          <div id="excluded_teams_no_bye" class="collapse">
-          {% for team in excluded_teams_no_bye %}
-          {{ team.name }}<br>
-          {% endfor %}
-          </div>
-        </div>
-        {% endif %}
-      </div>
-    </div><!-- end alert row -->
-
-    <div class="row">
-      {% for pairing in round_info %}
-      <div class="col-xl-6">
-      {% include "pairing/_pairing_card.html" %}
-      </div>
-      {% endfor %}
-    </div> <!-- end pairings row -->
-
-    <div class="row mt-2 mb-2">
-      <div class="col not-paired-in overflow-auto border-bottom">
-        <h5>People Not Paired In</h5>
-        <table class="table table-striped table-sm">
-          <thead>
-            <th>Checked in Teams ({{ excluded_teams|length }})</th>
-            <th>Checked in Judges ({{ excluded_judges|length }})</th>
-            <th>Non Checked in Judges ({{ non_checkins|length }})</th>
-            <th>Available Rooms ({{ available_rooms|length }})</th>
-          </thead>
-          {% for team, cjudge, judge, room in excluded_people %}
-          <tr>
-            <td>
-              {% if team %} <a href="/team/{{team.id}}" >{{team.name}}</a> {% endif %}
-            </td>
-            <td>
-              {% if cjudge %} <a href="/judge/{{cjudge.id}}" >{{cjudge.name}}</a> {% endif %}
-            </td>
-            <td>
-              {% if judge %} <a class="{% if judge.rank > warning %}text-danger{%endif%}"href="/judge/{{judge.id}}" >{{judge.name}}</a> {% endif %}
-            </td>
-            <td>
-              {% if room %} <a href="/room/{{room.id}}" >{{room.name}}</a> {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </table>
-      </div>
-    </div><!-- end not-paired-in row -->
-
-  </div>
-</div>
-{% endblock %}
+    </div>
+{% endblock content %}

--- a/mittab/templates/pairing/pairing_display.html
+++ b/mittab/templates/pairing/pairing_display.html
@@ -1,191 +1,151 @@
 <!DOCTYPE html>
-
-<html>
-<head>
-    {% load render_bundle from webpack_loader %}
-    {% render_bundle 'pairingDisplay' %}
-
-    <title>Pairings for Round {{round_number}}</title>
-
-    <meta name="round-number" content="{{ round_number }}">
-
-    <style type="text/css">
-    </style>
-</head>
-
-<body class="show-team-names">
-
-{% if pairing_exists %}
-    {% if printable %}
-        <!-- Center pairings table -->
-        <table class="pairings_table printable">
-        <tr>
-            <th>
-                Government
-            </th> <th>
-                Opposition
-            </th> <th>
-                Judge
-            </th> <th>
-                Room
-            </th>
-        </tr>
-        {% for pairing in round_pairing %}
-        <tr>
-            <td>
-                <div class="team-names">
-                    {{pairing.gov_team.display}}
-                </div>
-                {% if debater_team_memberships_public %}
-                <div class="member-names">
-                    {{pairing.gov_team.debaters_display}}
-                </div>
-                {% endif %}
-            </td>
-            <td>
-                <div class="team-names">
-                    {{pairing.opp_team.display}}
-                </div>
-                {% if debater_team_memberships_public %}
-                <div class="member-names">
-                    {{pairing.opp_team.debaters_display}}
-                </div>
-                {% endif %}
-            </td>
-            <td>
-                {% for judge in pairing.judges.all %}
-                    {% if pairing.judges.all|length > 1 and judge == pairing.chair %}
-                    <b>{{judge.name}}</b><br>
-                    {% else %}
-                    {{judge.name}}<br>
+<html lang="en">
+    <head>
+        {% load render_bundle from webpack_loader %}
+        {% render_bundle 'pairingDisplay' %}
+        <title>Pairings for Round {{ round_number }}</title>
+        <meta name="round-number" content="{{ round_number }}">
+        <style type="text/css"></style>
+    </head>
+    <body class="show-team-names">
+        {% if pairing_exists %}
+            {% if printable %}
+                <!-- Center pairings table -->
+                <table class="pairings_table printable">
+                    <tr>
+                        <th>Government</th>
+                        <th>Opposition</th>
+                        <th>Judge</th>
+                        <th>Room</th>
+                    </tr>
+                    {% for pairing in round_pairing %}
+                        <tr>
+                            <td>
+                                <div class="team-names">{{ pairing.gov_team.display }}</div>
+                                {% if debater_team_memberships_public %}
+                                    <div class="member-names">{{ pairing.gov_team.debaters_display }}</div>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <div class="team-names">{{ pairing.opp_team.display }}</div>
+                                {% if debater_team_memberships_public %}
+                                    <div class="member-names">{{ pairing.opp_team.debaters_display }}</div>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% for judge in pairing.judges.all %}
+                                    {% if pairing.judges.all|length > 1 and judge == pairing.chair %}
+                                        <b>{{ judge.name }}</b>
+                                        <br>
+                                    {% else %}
+                                        {{ judge.name }}
+                                        <br>
+                                    {% endif %}
+                                {% endfor %}
+                            </td>
+                            <td>{{ pairing.room.name }}</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+                <div class="pairings_footer_printable">
+                    {% if byes %}
+                        <span class="pairings_bye_label">Giving the Bye to:</span>
+                        {% for team in byes %}
+                            <span class="pairings_bye_entry">{{ team.display }}</span>
+                            {% if not forloop.last %},{% endif %}
+                        {% endfor %}
                     {% endif %}
-                {% endfor %}
-            </td>
-            <td>{{pairing.room.name}}</td>
-        </tr>
-        {% endfor %}
-        </table>
-        <div class="pairings_footer_printable">
-            {% if byes %}
-                <span class="pairings_bye_label">Giving the Bye to:</span>
-                {% for team in byes %}
-                <span class="pairings_bye_entry">{{team.display}}</span>
-                {% if not forloop.last %},{% endif%}
-                {% endfor %}
-            {% endif %}
-            {% if errors %}
-                <span class="pairings_bye_label">Teams not Paired in:</span>
-                {% for team in errors %}
-                <span class="pairings_bye_entry">{{team.display}}</span>
-                {% if not forloop.last %},{% endif%}
-                {% endfor %}
-            {% endif %}
-        </div>
-
-    {% else %}
-        <div id="scrollPage" class="hidden"></div>
-        <!-- Floating top header -->
-        <div class="pairings_header">
-          <h1>Pairings for Round {{round_number}} </h1>
-          <h3>({{team_count}} teams)</h3>
-
-          <table class="pairings_table">
-              <tr>
-              <th>
-                  Government
-              </th> <th>
-                  Opposition
-              </th> <th>
-                  Judge
-              </th> <th>
-                  Room
-              </th>
-              </tr>
-          </table>
-        </div>
-
-        <div class="pairings_header_spacer"></div>
-
-        <!-- Center pairings table -->
-        <table class="pairings_table">
-        {% for pairing in round_pairing %}
-        <tr>
-            <td>
-                <div class="team-names">
-                    {{pairing.gov_team.display}}
-                </div>
-                {% if debater_team_memberships_public %}
-                <div class="member-names">
-                    {{pairing.gov_team.debaters_display}}
-                </div>
-                {% endif %}
-            </td>
-            <td>
-                <div class="team-names">
-                    {{pairing.opp_team.display}}
-                </div>
-                {% if debater_team_memberships_public %}
-                <div class="member-names">
-                    {{pairing.opp_team.debaters_display}}
-                </div>
-                {% endif %}
-            </td>
-            <td>
-                {% for judge in pairing.judges.all %}
-                    {% if pairing.judges.all|length > 1 and judge == pairing.chair %}
-                    <b>{{judge.name}}</b><br>
-                    {% else %}
-                    {{judge.name}}<br>
+                    {% if errors %}
+                        <span class="pairings_bye_label">Teams not Paired in:</span>
+                        {% for team in errors %}
+                            <span class="pairings_bye_entry">{{ team.display }}</span>
+                            {% if not forloop.last %},{% endif %}
+                        {% endfor %}
                     {% endif %}
-                {% endfor %}
-            </td>
-            <td>{{pairing.room.name}}</td>
-        </tr>
-        {% endfor %}
-        </table>
-
-        <div class="pairings_footer_spacer"></div>
-
-        <!-- Floating bottom header -->
-        <div class="pairings_footer">
-            {% if byes %}
-                <span class="pairings_bye_label">Giving the Bye to:</span>
-                {% for team in byes %}
-                <span class="pairings_bye_entry">{{team.display}}</span>
-                {% if not forloop.last %},{% endif%}
-                {% endfor %}
+                </div>
+            {% else %}
+                <div id="scrollPage" class="hidden"></div>
+                <!-- Floating top header -->
+                <div class="pairings_header">
+                    <h1>Pairings for Round {{ round_number }}</h1>
+                    <h3>({{ team_count }} teams)</h3>
+                    <table class="pairings_table">
+                        <tr>
+                            <th>Government</th>
+                            <th>Opposition</th>
+                            <th>Judge</th>
+                            <th>Room</th>
+                        </tr>
+                    </table>
+                </div>
+                <div class="pairings_header_spacer"></div>
+                <!-- Center pairings table -->
+                <table class="pairings_table">
+                    {% for pairing in round_pairing %}
+                        <tr>
+                            <td>
+                                <div class="team-names">{{ pairing.gov_team.display }}</div>
+                                {% if debater_team_memberships_public %}
+                                    <div class="member-names">{{ pairing.gov_team.debaters_display }}</div>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <div class="team-names">{{ pairing.opp_team.display }}</div>
+                                {% if debater_team_memberships_public %}
+                                    <div class="member-names">{{ pairing.opp_team.debaters_display }}</div>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% for judge in pairing.judges.all %}
+                                    {% if pairing.judges.all|length > 1 and judge == pairing.chair %}
+                                        <b>{{ judge.name }}</b>
+                                        <br>
+                                    {% else %}
+                                        {{ judge.name }}
+                                        <br>
+                                    {% endif %}
+                                {% endfor %}
+                            </td>
+                            <td>{{ pairing.room.name }}</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+                <div class="pairings_footer_spacer"></div>
+                <!-- Floating bottom header -->
+                <div class="pairings_footer">
+                    {% if byes %}
+                        <span class="pairings_bye_label">Giving the Bye to:</span>
+                        {% for team in byes %}
+                            <span class="pairings_bye_entry">{{ team.display }}</span>
+                            {% if not forloop.last %},{% endif %}
+                        {% endfor %}
+                    {% endif %}
+                    {% if errors %}
+                        <span class="pairings_bye_label">Teams not Paired in:</span>
+                        {% for team in errors %}
+                            <span class="pairings_bye_entry">{{ team.display }}</span>
+                            {% if not forloop.last %},{% endif %}
+                        {% endfor %}
+                    {% endif %}
+                    {% if debater_team_memberships_public %}
+                        <span class="right">
+                            <label for="Member Names">
+                                Member Names:
+                                <input type="checkbox" name="names" id="name_display_toggle" />
+                            </label>
+                        </span>
+                    {% endif %}
+                    <span class="right">
+                        <label for="autoscroll">
+                            Autoscroll:
+                            <input type="checkbox" name="autoscroll" id="autoscroll" checked />
+                        </label>
+                    </span>
+                </div>
             {% endif %}
-            {% if errors %}
-                <span class="pairings_bye_label">Teams not Paired in:</span>
-                {% for team in errors %}
-                <span class="pairings_bye_entry">{{team.display}}</span>
-                {% if not forloop.last %},{% endif%}
-                {% endfor %}
-            {% endif %}
-            {% if debater_team_memberships_public %}
-            <span class="right">
-            <label for="Member Names">
-                Member Names:
-                <input type="checkbox" name="names" id="name_display_toggle"/>
-            </label>
-            </span>
-            {% endif %}
-            <span class="right">
-              <label for="autoscroll">
-                Autoscroll:
-                <input type="checkbox" name="autoscroll" id="autoscroll" checked/>
-              </label>
-            </span>
-        </div>
-    {% endif %}
-{% else %}
-
-    Round {{round_number}} does not yet have a valid pairing. Please wait until
-    your tournament directors release a valid pairing before viewing this page.
-
-{% endif %}
-
-</body>
-
+        {% else %}
+            Round {{ round_number }} does not yet have a valid pairing. Please wait until
+            your tournament directors release a valid pairing before viewing this page.
+        {% endif %}
+    </body>
 </html>
-

--- a/mittab/templates/pairing/room_dropdown.html
+++ b/mittab/templates/pairing/room_dropdown.html
@@ -1,29 +1,32 @@
 <div class="form-group pl-2 pt-2 mb-1">
-    <input id="quick-search" class="form-control form-control-sm" type="text" placeholder="Search...">
-  </div>
-  {% if current_room %}
-  <h6 class="text-center dropdown-header">Current Room</h6>
-  <a class="dropdown-item" href="/room/{{current_room.id}}">
-    {{current_room.name}}
-  </a>
-  <div class="dropdown-divider"></div>
-  {% endif %}
-
-  <h6 class="text-center dropdown-header">Viable Rooms Not Paired In</h6>
-  {% for room in viable_unpaired_rooms %}
-  <a href="#" class="dropdown-item room-assign searchable"  room-id="{{room.id}}" round-id="{{round_obj.id}}" current-room-id="{{current_room.id}}">
-    {{room.name}}
-  </a>
-  {% empty %}
-  <a class="dropdown-item">No viable rooms not paired in</a>
-  {% endfor %}
-
-  <div class="dropdown-divider"></div>
-  <h6 class="text-center dropdown-header">Viable Rooms Paired In</h6>
-  {% for room in viable_paired_rooms %}
-  <a href="#" class="dropdown-item room-assign searchable" room-id="{{room.id}}" round-id="{{round_obj.id}}" current-room-id="{{current_room.id}}">
-    {{room.name}}
-  </a>
-  {% empty %}
-  <a class="dropdown-item">No viable rooms paired in</a>
-  {% endfor %}
+    <input id="quick-search"
+           class="form-control form-control-sm"
+           type="text"
+           placeholder="Search...">
+</div>
+{% if current_room %}
+    <h6 class="text-center dropdown-header">Current Room</h6>
+    <a class="dropdown-item" href="/room/{{ current_room.id }}">{{ current_room.name }}</a>
+    <div class="dropdown-divider"></div>
+{% endif %}
+<h6 class="text-center dropdown-header">Viable Rooms Not Paired In</h6>
+{% for room in viable_unpaired_rooms %}
+    <a href="#"
+       class="dropdown-item room-assign searchable"
+       room-id="{{ room.id }}"
+       round-id="{{ round_obj.id }}"
+       current-room-id="{{ current_room.id }}">{{ room.name }}</a>
+{% empty %}
+    <a class="dropdown-item">No viable rooms not paired in</a>
+{% endfor %}
+<div class="dropdown-divider"></div>
+<h6 class="text-center dropdown-header">Viable Rooms Paired In</h6>
+{% for room in viable_paired_rooms %}
+    <a href="#"
+       class="dropdown-item room-assign searchable"
+       room-id="{{ room.id }}"
+       round-id="{{ round_obj.id }}"
+       current-room-id="{{ current_room.id }}">{{ room.name }}</a>
+{% empty %}
+    <a class="dropdown-item">No viable rooms paired in</a>
+{% endfor %}

--- a/mittab/templates/pairing/team_dropdown.html
+++ b/mittab/templates/pairing/team_dropdown.html
@@ -1,33 +1,32 @@
 <div class="form-group pl-2 pt-2 mb-1">
-  <input id="quick-search"
-        class="form-control form-control-sm" type="text" placeholder="Search...">
+    <input id="quick-search"
+           class="form-control form-control-sm"
+           type="text"
+           placeholder="Search...">
 </div>
-
 <h6 class="text-center dropdown-header">Team</h6>
-
-<a class="dropdown-item searchable" href="/team/{{current_team_id}}">
-  {{ current_team.display_backend }}
-</a>
+<a class="dropdown-item searchable" href="/team/{{ current_team_id }}">{{ current_team.display_backend }}</a>
 <div class="dropdown-divider"></div>
-<h6 class="text-center dropdown-header">
-  Teams Not Paired In
-</h6>
+<h6 class="text-center dropdown-header">Teams Not Paired In</h6>
 {% for team in excluded_teams %}
-<a href="#" class="dropdown-item team-assign searchable" position="{{position}}"
-            src-team-id="{{current_team_id}}" team-id="{{team.id}}" round-id="{{round_id}}">
-  {{ team.display_backend }}
-</a>
+    <a href="#"
+       class="dropdown-item team-assign searchable"
+       position="{{ position }}"
+       src-team-id="{{ current_team_id }}"
+       team-id="{{ team.id }}"
+       round-id="{{ round_id }}">{{ team.display_backend }}</a>
 {% empty %}
-<a class="dropdown-item">No teams</a>
+    <a class="dropdown-item">No teams</a>
 {% endfor %}
-
 <div class="dropdown-divider"></div>
 <h6 class="text-center dropdown-header">Teams Paired In</h6>
-{% for team in included_teams%}
-<a href="#" class="dropdown-item team-assign searchable" position="{{position}}"
-            src-team-id="{{current_team_id}}" team-id="{{team.id}}" round-id="{{round_id}}">
-  {{ team.display_backend }}
-</a>
+{% for team in included_teams %}
+    <a href="#"
+       class="dropdown-item team-assign searchable"
+       position="{{ position }}"
+       src-team-id="{{ current_team_id }}"
+       team-id="{{ team.id }}"
+       round-id="{{ round_id }}">{{ team.display_backend }}</a>
 {% empty %}
-<a class="dropdown-item">No teams</a>
+    <a class="dropdown-item">No teams</a>
 {% endfor %}

--- a/mittab/templates/public/judges.html
+++ b/mittab/templates/public/judges.html
@@ -1,48 +1,49 @@
 <!DOCTYPE html>
-
 {% load tags %}
-
-<html>
+<html lang="en">
     <head>
-	{% load render_bundle from webpack_loader %}
-	{% render_bundle 'publicDisplay' %}
-
-	<title>Judge List</title>
+        {% load render_bundle from webpack_loader %}
+        {% render_bundle 'publicDisplay' %}
+        <title>Judge List</title>
     </head>
     <body>
-        <div id="scrollPage" class="hidden"></div>	
-	<div class="public_header">
-	    <h1>Judge List</h1>
-	    <table class="public_table">
-		<tr>
-		    <th style="width: 25%;">Name</th>
-		    <th style="width: 40%;">Affiliations</th>
-		    {% for round in rounds %}
-			<th>R{{ round }}</th>
-		    {% endfor %}
-		</tr>
-	    </table>
-	</div>
-	<div class="public_header_spacer"></div>
-	<table class="public_table">
-	    {% for judge in judges %}
-		<tr>
-		    <td style="width: 25%;">{{ judge.name }}</td>
-		    <td style="width: 40%;">{{ judge.affiliations_display }}</td>
-		    {% for round in rounds %}
-			<td>{% if judge|is_checked_in:round %}&#10004;{% else %}X{% endif %}</td>
-		    {% endfor %}
-		</tr>
-	    {% endfor %}
-	</table>
+        <div id="scrollPage" class="hidden"></div>
+        <div class="public_header">
+            <h1>Judge List</h1>
+            <table class="public_table">
+                <tr>
+                    <th style="width: 25%;">Name</th>
+                    <th style="width: 40%;">Affiliations</th>
+                    {% for round in rounds %}<th>R{{ round }}</th>{% endfor %}
+                </tr>
+            </table>
+        </div>
+        <div class="public_header_spacer"></div>
+        <table class="public_table">
+            {% for judge in judges %}
+                <tr>
+                    <td style="width: 25%;">{{ judge.name }}</td>
+                    <td style="width: 40%;">{{ judge.affiliations_display }}</td>
+                    {% for round in rounds %}
+                        <td>
+                            {% if judge|is_checked_in:round %}
+                                {{ "✔" }}
+                            {% else %}
+                                X
+                            {% endif %}
+                        </td>
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </table>
         <div class="pairings_footer_spacer"></div>
-	<div class="public_footer">
+        <div class="public_footer">
             <span class="right">
-		<label for="autoscroll">
+                <label for="autoscroll">
                     Autoscroll:
-                    <input type="checkbox" name="autoscroll" id="autoscroll" checked/>
-		</label>
+                    <input type="checkbox" name="autoscroll" id="autoscroll" checked />
+                </label>
             </span>
-	</div>	
+        </div>
     </body>
 </html>

--- a/mittab/templates/public/teams.html
+++ b/mittab/templates/public/teams.html
@@ -1,16 +1,12 @@
 <!DOCTYPE html>
-
-<html>
+<html lang="en">
     <head>
         {% load render_bundle from webpack_loader %}
         {% render_bundle 'publicDisplay' %}
-
         <title>Team List</title>
     </head>
-
     <body>
         <div id="scrollPage" class="hidden"></div>
-
         <div class="public_header">
             <h1>Team List</h1>
             <h3>({{ num_checked_in }} checked in)</h3>
@@ -24,30 +20,26 @@
                 </tr>
             </table>
         </div>
-
         <div class="public_header_spacer"></div>
-
-		<table class="public_table">
-			{% for team in teams %}
-			<tr>
-				<td style="width: 25%;">{{ team.display }}</td>
-				<td style="width: 15%;">{{ team.school.display }}</td>
-				<td style="width: 15%;">{{ team.hybrid_school.name }}</td>
-				<td style="width: 30%;">{{ team.debaters_display }}</td>
-				<td style="width: 15%;">{{ team.checked_in|yesno:"Yes,No" }}</td>
-			</tr>
-			{% endfor %}
-		</table>
-
+        <table class="public_table">
+            {% for team in teams %}
+                <tr>
+                    <td style="width: 25%;">{{ team.display }}</td>
+                    <td style="width: 15%;">{{ team.school.display }}</td>
+                    <td style="width: 15%;">{{ team.hybrid_school.name }}</td>
+                    <td style="width: 30%;">{{ team.debaters_display }}</td>
+                    <td style="width: 15%;">{{ team.checked_in|yesno:"Yes,No" }}</td>
+                </tr>
+            {% endfor %}
+        </table>
         <div class="pairings_footer_spacer"></div>
-
-		<div class="public_footer">
+        <div class="public_footer">
             <span class="right">
-				<label for="autoscroll">
-					Autoscroll:
-					<input type="checkbox" name="autoscroll" id="autoscroll" checked/>
-				</label>
-			</span>
-		</div>
+                <label for="autoscroll">
+                    Autoscroll:
+                    <input type="checkbox" name="autoscroll" id="autoscroll" checked />
+                </label>
+            </span>
+        </div>
     </body>
 </html>

--- a/mittab/templates/registration/login.html
+++ b/mittab/templates/registration/login.html
@@ -1,82 +1,68 @@
 {% extends "base/__normal.html" %}
-
 {% block content %}
-
-<div class="col border-right pl-5 pr-5">
-  <h4 class="text-center">Tab Staff Login</h4>
-
-  {% if form.errors %}
-    <div class="alert alert-danger" role="alert">
-      Sorry, that's not a valid username or password
+    <div class="col border-right pl-5 pr-5">
+        <h4 class="text-center">Tab Staff Login</h4>
+        {% if form.errors %}
+            <div class="alert alert-danger" role="alert">Sorry, that's not a valid username or password</div>
+        {% endif %}
+        <form action="" method="post">
+            {% csrf_token %}
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text"
+                       class="form-control"
+                       name="username"
+                       value=""
+                       id="username"
+                       placeholder="Username">
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password"
+                       class="form-control"
+                       name="password"
+                       value=""
+                       id="password"
+                       placeholder="Password">
+            </div>
+            <button type="submit" class="btn btn-success btn-block">Sign in</button>
+            <input type="hidden" name="next" value="{{ next|escape }}" />
+        </form>
     </div>
-  {% endif %}
-
-  <form action="" method="post">
-    {% csrf_token %}
-    <div class="form-group">
-      <label for="username">Username</label>
-      <input type="text" class="form-control" name="username" value="" id="username" placeholder="Username">
+    <div class="col pl-5 pr-5">
+        <h4 class="text-center">Participant Access</h4>
+        <br />
+        <a class="btn btn-large btn-info btn-block"
+           href="/pairings/pairinglist/">Released Pairings</a>
+        <a class="btn btn-large btn-info btn-block"
+           href="/pairings/missing_ballots/">Missing Ballots</a>
+        <a class="btn btn-large btn-info btn-block content-reveal"
+           href="/e_ballots/"
+           data-to-reveal="e-ballot-search">Submit an E-Ballot</a>
+        <form action="/e_ballots/"
+              class="hidden mt-2"
+              method="post"
+              class="form-inline"
+              id="e-ballot-search"
+              enctyp="multipate/form-data">
+            {% csrf_token %}
+            <div class="input-group">
+                <input placeholder="Ballot code (get yours from tab)"
+                       id="e_ballot_search"
+                       class="form-control"
+                       name="ballot_code">
+                <div class="input-group-append">
+                    <input class="btn btn-info" type="submit" value="Get Ballot" />
+                </div>
+            </div>
+        </form>
+        <a class="btn btn-info btn-large btn-block mt-2"
+           href="{% url 'public_judges' %}">Judge List</a>
+        <a class="btn btn-info btn-large btn-block"
+           href="{% url 'public_teams' %}">Team List</a>
+        <a class="btn btn-info btn-large btn-block"
+           href="{% url 'outround_pretty_pair' 0 %}">Varsity Outrounds</a>
+        <a class="btn btn-info btn-large btn-block"
+           href="{% url 'outround_pretty_pair' 1 %}">Novice Outrounds</a>
     </div>
-    <div class="form-group">
-      <label for="password">Password</label>
-      <input type="password" class="form-control" name="password" value="" id="password" placeholder="Password">
-    </div>
-    <button type="submit" class="btn btn-success btn-block">Sign in</button>
-    <input type="hidden" name="next" value="{{ next|escape }}" />
-  </form>
-</div>
-
-<div class="col pl-5 pr-5">
-  <h4 class="text-center">Participant Access</h4>
-
-  <br/>
-
-  <a class="btn btn-large btn-info btn-block" href="/pairings/pairinglist/">
-    Released Pairings
-  </a>
-
-  <a class="btn btn-large btn-info btn-block" href="/pairings/missing_ballots/">
-    Missing Ballots
-  </a>
-
-  <a class="btn btn-large btn-info btn-block content-reveal"
-    href="/e_ballots/"
-    data-to-reveal="e-ballot-search">
-    Submit an E-Ballot
-  </a>
-
-  <form action="/e_ballots/" class="hidden mt-2" method="post" class="form-inline"
-    id="e-ballot-search" enctyp="multipate/form-data">
-    {% csrf_token %}
-
-    <div class="input-group">
-      <input placeholder="Ballot code (get yours from tab)"
-             id="e_ballot_search" class="form-control"
-             name="ballot_code">
-      <div class="input-group-append">
-        <input class="btn btn-info" type="submit" value="Get Ballot"/>
-      </div>
-    </div>
-  </form>
-
-  <a class="btn btn-info btn-large btn-block mt-2"
-     href="{% url 'public_judges' %}">
-      Judge List
-  </a>
-
-  <a class="btn btn-info btn-large btn-block"
-     href="{% url 'public_teams' %}">
-      Team List
-  </a>
-
-  <a class="btn btn-info btn-large btn-block"
-     href="{% url 'outround_pretty_pair' 0 %}">
-      Varsity Outrounds
-  </a>
-
-  <a class="btn btn-info btn-large btn-block"
-     href="{% url 'outround_pretty_pair' 1 %}">
-      Novice Outrounds
-  </a>
-</div>
-{% endblock %}
+{% endblock content %}

--- a/mittab/templates/tab/all_tab_cards.html
+++ b/mittab/templates/tab/all_tab_cards.html
@@ -1,8 +1,7 @@
 <head>
-  {% load render_bundle from webpack_loader %}
-  {% render_bundle 'main' 'js' %}
-
-  <style>
+    {% load render_bundle from webpack_loader %}
+    {% render_bundle 'main' 'js' %}
+    <style>
 div.printable {
     width: 7in;
     margin-bottom: 2em;
@@ -33,14 +32,12 @@ table#pairing_list td{
 .center {
     text-align: center;
 }
-  </style>
+    </style>
 </head>
-
 {% for team in all_teams %}
-<h3>Team: {{ team.display_backend }}</h3>
-<div class="printable tab_card_item {% if forloop.counter|divisibleby:2 %}page_break_after{% endif %}" data-team-id={{team.id}}>
-  <small>Loading...</small>
-</div>
-
+    <h3>Team: {{ team.display_backend }}</h3>
+    <div class="printable tab_card_item {% if forloop.counter|divisibleby:2 %}page_break_after{% endif %}"
+         data-team-id="{{ team.id }}">
+        <small>Loading...</small>
+    </div>
 {% endfor %}
-

--- a/mittab/templates/tab/pretty_tab_card.html
+++ b/mittab/templates/tab/pretty_tab_card.html
@@ -1,17 +1,15 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}Tab Card for {{team.display_backend}}{% endblock %}
-
-{% block banner %}Tab Card for {{team.display_backend}} {% endblock %}
-
+{% block title %}
+    Tab Card for {{ team.display_backend }}
+{% endblock title %}
+{% block banner %}
+    Tab Card for {{ team.display_backend }}
+{% endblock banner %}
 {% block content %}
-
-<div class="col">
-  <a class="btn btn-secondary" href="/team/{{team.id}}/">View {{team.display_backend}}</a>
-
-  <div style="padding:1em 0 0"></div>
-  <div class="tab_card_item" data-team-id={{team.id}}></div>
-</div>
-{% endblock %}
-
-
+    <div class="col">
+        <a class="btn btn-secondary" href="/team/{{ team.id }}/">View {{ team.display_backend }}</a>
+        <div style="padding:1em 0 0"></div>
+        <div class="tab_card_item" data-team-id={{ team.id }}>
+        </div>
+    </div>
+{% endblock content %}

--- a/mittab/templates/tab/rank_debaters.html
+++ b/mittab/templates/tab/rank_debaters.html
@@ -1,16 +1,16 @@
 {% extends "base/__wide.html" %}
-
-{% block title %} {{title}} {% endblock %}
-
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    {{ title }}
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
-<div class="col" id="debater_ranking">
-  <div class="d-flex justify-content-center p-5">
-    <div class="spinner-border" role="status">
-      <span class="sr-only">Loading...</span>
+    <div class="col" id="debater_ranking">
+        <div class="d-flex justify-content-center p-5">
+            <div class="spinner-border" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+        </div>
     </div>
-  </div>
-</div>
-
-{% endblock %}
+{% endblock content %}

--- a/mittab/templates/tab/rank_debaters_component.html
+++ b/mittab/templates/tab/rank_debaters_component.html
@@ -1,51 +1,57 @@
 <div class="col-12">
-    <a href="{% url 'cache_refresh' %}?key=speaker_rankings&next={% url 'rank_teams_ajax' %}">
-	Force Refresh
-    </a>
+    <a href="{% url 'cache_refresh' %}?key=speaker_rankings&next={% url 'rank_teams_ajax' %}">Force Refresh</a>
 </div>
 <div class="col-6">
-  <h5 class="text-center">Varsity Ranking</h5>
-  <table class="table table-striped table-sm table-bordered">
-    <thead>
-      <th>#</th>
-      <th>Name</th>
-      <th>Speaks</th>
-      <th>Ranks</th>
-      <th>Team</th>
-      <th title="Tiebreaker between the debater and the next-best debater">Tiebreaker</th>
-    </thead>
-    {% for debater, speaks, ranks, team, tiebreaker in debaters %}
-    <tr>
-      <td> {{ forloop.counter }} </td>
-      <td> <a href="/debater/{{ debater.id }}">{{ debater.name }}</a></td>
-      <td> {{ speaks|floatformat:2 }}</td>
-      <td> {{ ranks|floatformat:2 }}</td>
-      <td> <a href="/team/{{ team.id }}/">{{ team.name }}</a></td>
-      <td>{{ tiebreaker }}</td>
-    </tr>
-    {% endfor %}
-  </table>
+    <h5 class="text-center">Varsity Ranking</h5>
+    <table class="table table-striped table-sm table-bordered">
+        <thead>
+            <th>#</th>
+            <th>Name</th>
+            <th>Speaks</th>
+            <th>Ranks</th>
+            <th>Team</th>
+            <th title="Tiebreaker between the debater and the next-best debater">Tiebreaker</th>
+        </thead>
+        {% for debater, speaks, ranks, team, tiebreaker in debaters %}
+            <tr>
+                <td>{{ forloop.counter }}</td>
+                <td>
+                    <a href="/debater/{{ debater.id }}">{{ debater.name }}</a>
+                </td>
+                <td>{{ speaks|floatformat:2 }}</td>
+                <td>{{ ranks|floatformat:2 }}</td>
+                <td>
+                    <a href="/team/{{ team.id }}/">{{ team.name }}</a>
+                </td>
+                <td>{{ tiebreaker }}</td>
+            </tr>
+        {% endfor %}
+    </table>
 </div>
 <div class="col-6">
-  <h5 class="text-center">Novice Ranking</h5>
-  <table class="table table-striped table-sm table-bordered">
-    <thead>
-      <th>#</th>
-      <th>Name</th>
-      <th>Speaks</th>
-      <th>Ranks</th>
-      <th>Team</th>
-      <th title="Tiebreaker between the debater and the next-best debater">Tiebreaker</th>
-    </thead>
-    {% for debater, speaks, ranks, team, tiebreaker in nov_debaters %}
-    <tr>
-      <td>{{ forloop.counter }}</td>
-      <td><a href="/debater/{{ debater.id }}">{{ debater.name }}</a></td>
-      <td>{{ speaks|floatformat:2 }}</td>
-      <td>{{ ranks|floatformat:2 }}</td>
-      <td> <a href="/team/{{ team.id }}/">{{ team.name }}</a></td>
-      <td>{{ tiebreaker }}</td>
-    </tr>
-    {% endfor %}
-  </table>
+    <h5 class="text-center">Novice Ranking</h5>
+    <table class="table table-striped table-sm table-bordered">
+        <thead>
+            <th>#</th>
+            <th>Name</th>
+            <th>Speaks</th>
+            <th>Ranks</th>
+            <th>Team</th>
+            <th title="Tiebreaker between the debater and the next-best debater">Tiebreaker</th>
+        </thead>
+        {% for debater, speaks, ranks, team, tiebreaker in nov_debaters %}
+            <tr>
+                <td>{{ forloop.counter }}</td>
+                <td>
+                    <a href="/debater/{{ debater.id }}">{{ debater.name }}</a>
+                </td>
+                <td>{{ speaks|floatformat:2 }}</td>
+                <td>{{ ranks|floatformat:2 }}</td>
+                <td>
+                    <a href="/team/{{ team.id }}/">{{ team.name }}</a>
+                </td>
+                <td>{{ tiebreaker }}</td>
+            </tr>
+        {% endfor %}
+    </table>
 </div>

--- a/mittab/templates/tab/rank_teams.html
+++ b/mittab/templates/tab/rank_teams.html
@@ -1,15 +1,16 @@
 {% extends "base/__wide.html" %}
-
-{% block title %} {{title}} {% endblock %}
-
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    {{ title }}
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
     <div class="col" id="team_ranking">
-	<div class="d-flex justify-content-center p-5">
-	    <div class="spinner-border" role="status">
-		<span class="sr-only">Loading...</span>
-	    </div>
-	</div>
+        <div class="d-flex justify-content-center p-5">
+            <div class="spinner-border" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+        </div>
     </div>
-{% endblock %}
+{% endblock content %}

--- a/mittab/templates/tab/rank_teams_component.html
+++ b/mittab/templates/tab/rank_teams_component.html
@@ -1,51 +1,53 @@
 <div class="col-12">
-    <a href="{% url 'cache_refresh' %}?key=team_rankings&next={% url 'rank_teams_ajax' %}">
-	Force Refresh
-    </a>
+    <a href="{% url 'cache_refresh' %}?key=team_rankings&next={% url 'rank_teams_ajax' %}">Force Refresh</a>
 </div>
 <div class="col-6">
-  <h5 class="text-center">Varsity Ranking</h5>
-  <table class="table table-striped table-sm table-bordered">
-    <thead>
-      <th>#</th>
-      <th>Team Name</th>
-      <th>Wins</th>
-      <th>Speaks</th>
-      <th>Ranks</th>
-      <th title="Tiebreaker between the team and the next-best team">Tiebreaker</th>
-    </thead>
-    {% for team, wins, speaks, ranks, tiebreaker in varsity %}
-    <tr>
-        <td>{{ forloop.counter }}</td>
-        <td><a href="/team/{{ team.id }}">{{ team.display_backend }}</a></td>
-        <td>{{ wins }}</td>
-        <td>{{ speaks|floatformat:2 }}</td>
-        <td>{{ ranks|floatformat:2 }}</td>
-        <td>{{ tiebreaker }}</td>
-    </tr>
-    {% endfor %}
-  </table>
+    <h5 class="text-center">Varsity Ranking</h5>
+    <table class="table table-striped table-sm table-bordered">
+        <thead>
+            <th>#</th>
+            <th>Team Name</th>
+            <th>Wins</th>
+            <th>Speaks</th>
+            <th>Ranks</th>
+            <th title="Tiebreaker between the team and the next-best team">Tiebreaker</th>
+        </thead>
+        {% for team, wins, speaks, ranks, tiebreaker in varsity %}
+            <tr>
+                <td>{{ forloop.counter }}</td>
+                <td>
+                    <a href="/team/{{ team.id }}">{{ team.display_backend }}</a>
+                </td>
+                <td>{{ wins }}</td>
+                <td>{{ speaks|floatformat:2 }}</td>
+                <td>{{ ranks|floatformat:2 }}</td>
+                <td>{{ tiebreaker }}</td>
+            </tr>
+        {% endfor %}
+    </table>
 </div>
 <div class="col-6">
-  <h5 class="text-center">Novice Ranking</h5>
-  <table class="table table-striped table-sm table-bordered">
-    <thead>
-      <th>#</th>
-      <th>Team Name</th>
-      <th>Wins</th>
-      <th>Speaks</th>
-      <th>Ranks</th>
-      <th title="Tiebreaker between the team and the next-best team">Tiebreaker</th>
-    </thead>
-    {% for team, wins, speaks, ranks, tiebreaker in novice %}
-    <tr>
-        <td>{{ forloop.counter }}</td>
-        <td><a href="/team/{{ team.id }}">{{ team.display_backend }}</a></td>
-        <td>{{ wins }}</td>
-        <td>{{ speaks|floatformat:2 }}</td>
-        <td>{{ ranks|floatformat:2 }}</td>
-        <td>{{ tiebreaker }}</td>
-    </tr>
-    {% endfor %}
-  </table>
+    <h5 class="text-center">Novice Ranking</h5>
+    <table class="table table-striped table-sm table-bordered">
+        <thead>
+            <th>#</th>
+            <th>Team Name</th>
+            <th>Wins</th>
+            <th>Speaks</th>
+            <th>Ranks</th>
+            <th title="Tiebreaker between the team and the next-best team">Tiebreaker</th>
+        </thead>
+        {% for team, wins, speaks, ranks, tiebreaker in novice %}
+            <tr>
+                <td>{{ forloop.counter }}</td>
+                <td>
+                    <a href="/team/{{ team.id }}">{{ team.display_backend }}</a>
+                </td>
+                <td>{{ wins }}</td>
+                <td>{{ speaks|floatformat:2 }}</td>
+                <td>{{ ranks|floatformat:2 }}</td>
+                <td>{{ tiebreaker }}</td>
+            </tr>
+        {% endfor %}
+    </table>
 </div>

--- a/mittab/templates/tab/settings_form.html
+++ b/mittab/templates/tab/settings_form.html
@@ -1,14 +1,15 @@
 {% extends "base/__normal.html" %}
-
-{% block title %}Data Entry{% endblock %}
-
-{% block banner %} {{title}} {% endblock %}
-
+{% block title %}
+    Data Entry
+{% endblock title %}
+{% block banner %}
+    {{ title }}
+{% endblock banner %}
 {% block content %}
-<div class="col-md-6">
-  {% include "common/_form.html" %}
-</div>
-<div class="col-md-6">
-    <div class="alert alert-warning">Please be careful editing these settings.  If you require assistance, please check out the <a href="https://mit-tab.readthedocs.io/en/latest/Advanced-Topics.html"> documentation!</a>
-</div>
-{% endblock %}
+    <div class="col-md-6">{% include "common/_form.html" %}</div>
+    <div class="col-md-6">
+        <div class="alert alert-warning">
+            Please be careful editing these settings.  If you require assistance, please check out the <a href="https://mit-tab.readthedocs.io/en/latest/Advanced-Topics.html">documentation!</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/mittab/templates/tab/tab_card.html
+++ b/mittab/templates/tab/tab_card.html
@@ -1,33 +1,29 @@
 <table id="pairing_list" class="table-bordered table">
-<thead>
-    <th>R</th>
-    <th>G/O</th>
-    <th>W/L</th>
-    <th>Opponent</th>
-    <th>Judge</th>
-    <th>
-      {{debater_1}} ({{debater_1_status|slice:":1" }})
-    </th>
-    <th>
-      {{debater_2}} ({{debater_2_status|slice:":1" }})
-    </th>
-    <th>Total</th>
-</thead>
-{% for round_stat in round_stats %}
-<tr>
-    <td>{{forloop.counter}}</td>
-    {% ifequal forloop.counter bye_round %}
-    <td>BYE</td>
-    {% else %}
-    <td>{{round_stat.0}}</td>
-    {% endifequal %}
-    <td>{{round_stat.1}}</td>
-    <td>{{round_stat.2}}</td>
-    <td>{{round_stat.3}}</td>
-    <td>{{round_stat.4}}</td>
-    <td>{{round_stat.5}}</td>
-    <td>{{round_stat.6}}</td>
-</tr>
+    <thead>
+        <th>R</th>
+        <th>G/O</th>
+        <th>W/L</th>
+        <th>Opponent</th>
+        <th>Judge</th>
+        <th>{{ debater_1 }} ({{ debater_1_status|slice:":1" }})</th>
+        <th>{{ debater_2 }} ({{ debater_2_status|slice:":1" }})</th>
+        <th>Total</th>
+    </thead>
+    {% for round_stat in round_stats %}
+        <tr>
+            <td>{{ forloop.counter }}</td>
+            {% ifequal forloop.counter bye_round %}
+            <td>BYE</td>
+        {% else %}
+            <td>{{ round_stat.0 }}</td>
+        {% endifequal %}
+        <td>{{ round_stat.1 }}</td>
+        <td>{{ round_stat.2 }}</td>
+        <td>{{ round_stat.3 }}</td>
+        <td>{{ round_stat.4 }}</td>
+        <td>{{ round_stat.5 }}</td>
+        <td>{{ round_stat.6 }}</td>
+    </tr>
 {% endfor %}
 <tr>
     <td colspan=5>Tournament Totals:</td>


### PR DESCRIPTION
Add linting and formatting for HTML to the CircleCi, and apply to all HTML templates. Should make HTML formatting/development much easier. Jinja/django specific compatible linter used. Most linting problems are fixable with built in formatter `djlint . --reformat --quiet`

Essentially all changes made with the autoformatter, with main exceptions of
1. add closing to orphan tags
2. add language to HTML tags
3. add name to endblock stags (eg. `{% endblock %} -> `{% endblock content %}`

Edit: Cherrypicked away from the python 3.10 branch. No longer depends on any other branches.