### PR TITLE
Tab Card Patch

### DIFF
--- a/mittab/apps/tab/team_views.py
+++ b/mittab/apps/tab/team_views.py
@@ -293,11 +293,8 @@ def tab_card(request, team_id):
     for round_obj in rounds:
         round_number = round_obj.round_number
 
-        dstat1 = round_stats_by_round_and_debater_id[round_number][deb1.id]
-
-        dstat2 = []
-        if not iron_man:
-            dstat2 = round_stats_by_round_and_debater_id[round_number][deb2.id]
+        dstat1 = round_stats_by_round_and_debater_id[round_number].get(deb1.id, [])
+        dstat2 = round_stats_by_round_and_debater_id[round_number].get(deb2.id, [])
 
         blank_rs = RoundStats(debater=deb1, round=round_obj, speaks=0, ranks=0)
 


### PR DESCRIPTION
Fix recent bug that causes tab cards with single round iron persons to not load. Bug comes from the replacement of 

 `dstat2 = [k for k in RoundStats.objects.filter(debater=deb2).filter(round=round_obj).all()]`
with
`dstat2 = round_stats_by_round_and_debater_id[round_number][deb2.id]`

Which fixed the N+1, but isn't null safe. `if iron_person` doesn't fix the problem because teams that iron personed some but not all rounds have `iron_person=False`. Replacement should fix the problem, and be a little simpler.