### PR TITLE
try to fix failing circle-ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,18 @@ jobs:
       - checkout
       - restore_cache:
           key: deps-v2-{{ checksum "Pipfile.lock" }}
-
+      - run:
+        name: Fix EOL Debian Buster APT sources
+        command: |
+          sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
+          sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
+          echo 'Acquire::Check-Valid-Until "false";' | sudo tee /etc/apt/apt.conf.d/99no-check-valid
+          sudo apt-get -o Acquire::Check-Valid-Until=false update
       - run:
           name: install dependencies
           command: |
             sudo apt-get update
             sudo apt-get upgrade -y
-            sudo apt-get install
             sudo apt-get install -y default-mysql-client
             sudo pip install pipenv
             pipenv install
@@ -83,11 +88,17 @@ jobs:
       - restore_cache:
           key: deps-v2-{{ checksum "Pipfile.lock" }}
       - run:
+          name: Fix EOL Debian Buster APT sources
+          command: |
+            sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
+            sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
+            echo 'Acquire::Check-Valid-Until "false";' | sudo tee /etc/apt/apt.conf.d/99no-check-valid
+            sudo apt-get -o Acquire::Check-Valid-Until=false update
+      - run:
           name: install dependencies
           command: |
             sudo apt-get update
             sudo apt-get upgrade -y
-            sudo apt-get install
             sudo apt-get install -y default-mysql-client
             sudo pip install pipenv
             pipenv install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,12 @@ jobs:
       - restore_cache:
           key: deps-v2-{{ checksum "Pipfile.lock" }}
       - run:
-        name: Fix EOL Debian Buster APT sources
-        command: |
-          sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
-          sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
-          echo 'Acquire::Check-Valid-Until "false";' | sudo tee /etc/apt/apt.conf.d/99no-check-valid
-          sudo apt-get -o Acquire::Check-Valid-Until=false update
+          name: Fix EOL Debian Buster APT sources
+          command: |
+            sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
+            sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
+            echo 'Acquire::Check-Valid-Until "false";' | sudo tee /etc/apt/apt.conf.d/99no-check-valid
+            sudo apt-get -o Acquire::Check-Valid-Until=false update
       - run:
           name: install dependencies
           command: |


### PR DESCRIPTION
Ugly short term fix to getting lint and built tests passing again with the EOL images. Eventually can be removed if we get back to a LTS python version