### PR TITLE
fix inround tab cards

### DIFF
--- a/mittab/apps/tab/team_views.py
+++ b/mittab/apps/tab/team_views.py
@@ -292,9 +292,11 @@ def tab_card(request, team_id):
 
     for round_obj in rounds:
         round_number = round_obj.round_number
-
-        dstat1 = round_stats_by_round_and_debater_id[round_number].get(deb1.id, [])
-        dstat2 = round_stats_by_round_and_debater_id[round_number].get(deb2.id, [])
+        dstat1 = []
+        dstat2 = []
+        if round_number in round_stats_by_round_and_debater_id:
+            dstat1 = round_stats_by_round_and_debater_id[round_number].get(deb1.id, [])
+            dstat2 = round_stats_by_round_and_debater_id[round_number].get(deb2.id, [])
 
         blank_rs = RoundStats(debater=deb1, round=round_obj, speaks=0, ranks=0)
 


### PR DESCRIPTION
Could have sworn I already fixed this, but getting reports it was broken again and was able to replicate it. Simple fix, we can't assume round stats are populated before results are in