### PR TITLE
Remove setting for apda_id

### DIFF
--- a/mittab/apps/tab/forms.py
+++ b/mittab/apps/tab/forms.py
@@ -26,9 +26,6 @@ class UploadDataForm(forms.Form):
 class SchoolForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(SchoolForm, self).__init__(*args, **kwargs)
-        if TabSettings.get("apda_tournament", 0) == 0:
-            if "apda_id" in self.fields:
-                del self.fields["apda_id"]
 
     class Meta:
         model = School
@@ -233,9 +230,7 @@ class ScratchForm(forms.ModelForm):
 class DebaterForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(DebaterForm, self).__init__(*args, **kwargs)
-        if TabSettings.get("apda_tournament", 0) == 0:
-            if "apda_id" in self.fields:
-                del self.fields["apda_id"]
+
     class Meta:
         model = Debater
         exclude = ["tiebreaker"]

--- a/mittab/apps/tab/middleware.py
+++ b/mittab/apps/tab/middleware.py
@@ -53,12 +53,6 @@ class TournamentStatusCheck:
         if not request.path.startswith("/api/"):
             return self.get_response(request)
 
-        if not TabSettings.get("apda_tournament", False):
-            return JsonResponse({
-                "error": "Tournament is not sanctioned. Please check and update "
-                         "the \"apda_tournament\" setting if this message is incorrect."
-            }, status=403)
-
         finals = Outround.objects.filter(num_teams=2)
         if not finals.exists() or finals.filter(victor=Outround.UNKNOWN).exists():
             return JsonResponse({"error": "Tournament incomplete"}, status=409)

--- a/settings.yaml
+++ b/settings.yaml
@@ -60,8 +60,3 @@
   description: "Toggle to enable room seeding. When enabled, the best rooms go to the highest seeded rooms."
   value: true
   type: boolean
-- apda_tournament:
-  name: apda_tournament
-  description: "A toggle to indicate whether this is an officially sanctioned APDA tournament. If true, the APDA IDs will be used for the tournament."
-  value: false
-  type: boolean


### PR DESCRIPTION
Reversing course on this for a few reasons:
1. In the final design on the API import we used over on standings, we ended up just letting URL be a text input rather than having a dashboard for active tournaments, so the original purpose of telling standings which tournaments to include on the dashboard isn't really relevant anymore
2. When you do spreadsheet import, if you forgot to turn the setting on, the IDs won't import and you have to try again. This is a result of removing IDs from the forms, because the spreadsheet import creates the objects using the forms for validation. Plenty of other ways to fix this, but since the original purpose is moot, it wouldn't be worth the added complexity