### PR TITLE
Disable autoscroll default

### DIFF
--- a/assets/js/scroller.js
+++ b/assets/js/scroller.js
@@ -32,12 +32,11 @@ setupScroll = () => {
 };
 
 $(document).ready(() => {
-  $("#autoscroll").change(function() {
+  $("#autoscroll").change(function handleAutoscrollChange() {
     if ($(this).prop("checked")) {
       setupScroll();
     } else {
       window.clearInterval(timer);
     }
   });
-
 });

--- a/assets/js/scroller.js
+++ b/assets/js/scroller.js
@@ -32,7 +32,7 @@ setupScroll = () => {
 };
 
 $(document).ready(() => {
-  $("#autoscroll").change(() => {
+  $("#autoscroll").change(function() {
     if ($(this).prop("checked")) {
       setupScroll();
     } else {
@@ -40,5 +40,4 @@ $(document).ready(() => {
     }
   });
 
-  setupScroll();
 });

--- a/mittab/templates/outrounds/pretty_pairing.html
+++ b/mittab/templates/outrounds/pretty_pairing.html
@@ -212,7 +212,7 @@
 	    <span class="right">
 		<label for="autoscroll">
 		    Autoscroll:
-		    <input type="checkbox" name="autoscroll" id="autoscroll" checked/>
+		    <input type="checkbox" name="autoscroll" id="autoscroll"/>
 		</label>
 	    </span>
         </div>

--- a/mittab/templates/pairing/pairing_display.html
+++ b/mittab/templates/pairing/pairing_display.html
@@ -174,7 +174,7 @@
             <span class="right">
               <label for="autoscroll">
                 Autoscroll:
-                <input type="checkbox" name="autoscroll" id="autoscroll" checked/>
+                <input type="checkbox" name="autoscroll" id="autoscroll"/>
               </label>
             </span>
         </div>


### PR DESCRIPTION
Fixing two super nit-picky bugs
1. Auto-scroll is on by default. Since it's only used on a projector and is a bit of a nuance to people looking on a personal device, it would be a bit better to disable
2. when you turn on turn off auto-scroll, then turn it back on, it doesn't re-enable