### PR TITLE
fix duplicate checkin

### DIFF
--- a/mittab/apps/tab/migrations/0029_unique_checkins.py
+++ b/mittab/apps/tab/migrations/0029_unique_checkins.py
@@ -1,0 +1,27 @@
+# Generated manually to enforce unique check-ins per round.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tab", "0028_team_ranking_public"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="checkin",
+            constraint=models.UniqueConstraint(
+                fields=("judge", "round_number"),
+                name="unique_judge_checkin_per_round",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="roomcheckin",
+            constraint=models.UniqueConstraint(
+                fields=("room", "round_number"),
+                name="unique_room_checkin_per_round",
+            ),
+        ),
+    ]

--- a/mittab/apps/tab/models.py
+++ b/mittab/apps/tab/models.py
@@ -599,6 +599,14 @@ class CheckIn(models.Model):
         return "Judge %s is checked in for round %s" % (self.judge,
                                                         self.round_number)
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["judge", "round_number"],
+                name="unique_judge_checkin_per_round",
+            )
+        ]
+
 
 class RoomCheckIn(models.Model):
     room = models.ForeignKey(Room, on_delete=models.CASCADE)
@@ -607,6 +615,14 @@ class RoomCheckIn(models.Model):
     def __str__(self):
         return "Room %s is checked in for round %s" % (self.room,
                                                        self.round_number)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["room", "round_number"],
+                name="unique_room_checkin_per_round",
+            )
+        ]
 
 
 class RoomTag(models.Model):


### PR DESCRIPTION
The new bulk checkin utilities prevent duplicates with bulk create no conficts = true. This was a mistake because we have no database validation preventing duplicates. This change just adds that validation