### PR TITLE
fix agreement between new judge features and wing only setting

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -115,3 +115,7 @@ $font-size-base: 0.95rem !default;
 .warning-container:hover .warning-popup {
   display: block;
 }
+
+.badge-wing-only {
+  font-size: 0.6rem;
+}

--- a/mittab/apps/tab/outround_pairing_views.py
+++ b/mittab/apps/tab/outround_pairing_views.py
@@ -374,12 +374,12 @@ def alternative_judges(request, round_id, judge_id=None):
         return any(s.team_id in scratched_team_ids for s in judge.scratches.all())
 
     excluded_judges = [
-        (j.name, j.id, float(j.rank))
+        (j.name, j.id, float(j.rank), j.wing_only)
         for j in excluded_judges
         if not has_team_scratch(j)
     ]
     included_judges = [
-        (j.name, j.id, float(j.rank))
+        (j.name, j.id, float(j.rank), j.wing_only)
         for j in included_judges
         if not has_team_scratch(j)
     ]

--- a/mittab/apps/tab/pairing_views.py
+++ b/mittab/apps/tab/pairing_views.py
@@ -477,11 +477,11 @@ def alternative_judges(request, round_id, judge_id=None):
     )
 
     excluded_judges = [
-        (j.name, j.id, float(j.rank), rejudge_display_counts.get(j.id))
+        (j.name, j.id, float(j.rank), rejudge_display_counts.get(j.id), j.wing_only)
         for j in excluded_judges_list
     ]
     included_judges = [
-        (j.name, j.id, float(j.rank), rejudge_display_counts.get(j.id))
+        (j.name, j.id, float(j.rank), rejudge_display_counts.get(j.id), j.wing_only)
         for j in included_judges_list
     ]
     included_judges = sorted(included_judges, key=lambda x: -x[2])

--- a/mittab/libs/assign_judges.py
+++ b/mittab/libs/assign_judges.py
@@ -80,23 +80,26 @@ def add_judges():
     Round.judges.through.objects.filter(
         round__round_number=round_number
     ).delete()
-    judges = list(
+    # Get all checked-in judges
+    all_judges = list(
         Judge.objects.filter(
-            checkin__round_number=round_number,
-            wing_only=False
+            checkin__round_number=round_number
         ).prefetch_related(
             "judges",  # poorly named relation for the round
             "scratches",
         )
     )
+    # Separate chairs (non-wing-only judges) and wings (wing-only judges)
+    chairs = [j for j in all_judges if not j.wing_only]
     pairings = tab_logic.sorted_pairings(round_number)
 
     random.seed(1337)
     random.shuffle(pairings)
-    random.seed(1337)
-    random.shuffle(judges)
-    judges = sorted(judges, key=lambda j: j.rank, reverse=True)
-    judge_scores = construct_judge_scores(judges, settings.mode)
+
+    chairs = sorted(chairs, key=lambda j: j.rank, reverse=True)
+    chair_scores = construct_judge_scores(chairs, settings.mode)
+    all_judges = sorted(all_judges, key=lambda j: j.rank, reverse=True)
+
     bubble_priority = settings.round_priority == InroundRoundPriority.BUBBLE_ROUNDS
     if bubble_priority and round_number > 1:
         bubble_rounds = [p for p in pairings if is_bubble_round(p, round_number)]
@@ -116,23 +119,23 @@ def add_judges():
         all_teams.extend((pairing.gov_team, pairing.opp_team))
     rejudge_counts = {}
     if settings.allow_rejudges:
-        rejudge_counts = judge_team_rejudge_counts(judges, all_teams)
+        rejudge_counts = judge_team_rejudge_counts(chairs, all_teams)
 
     graph_edges = []
-    for judge_i, judge in enumerate(judges):
-        judge_score = judge_scores[judge_i]
+    for chair_i, chair in enumerate(chairs):
+        chair_score = chair_scores[chair_i]
 
         for pairing_i, pairing in enumerate(pairings):
             has_conflict = judge_conflict(
-                judge,
+                chair,
                 pairing.gov_team,
                 pairing.opp_team,
                 settings.allow_rejudges,
             )
             if has_conflict:
                 continue
-            weight = calc_weight(judge_score, pairing_i, settings.mode)
-            judge_counts = rejudge_counts.get(judge.id)
+            weight = calc_weight(chair_score, pairing_i, settings.mode)
+            judge_counts = rejudge_counts.get(chair.id)
             rejudge_sum = 0
             if judge_counts:
                 rejudge_sum = (
@@ -140,66 +143,84 @@ def add_judges():
                     + judge_counts.get(pairing.opp_team.id, 0)
                 )
             if rejudge_sum > 0 and settings.rejudge_penalty > 0:
-                penalty = settings.rejudge_penalty * (1 + 0.1 * judge_score)
+                penalty = settings.rejudge_penalty * (1 + 0.1 * chair_score)
                 weight -= penalty * rejudge_sum
 
-            graph_edges.append((pairing_i, num_rounds + judge_i, weight))
+            graph_edges.append((pairing_i, num_rounds + chair_i, weight))
     judge_assignments = mwmatching.maxWeightMatching(graph_edges, maxcardinality=True)
 
     if -1 in judge_assignments[:num_rounds] or (num_rounds > 0 and not graph_edges):
         if not graph_edges:
-            raise errors.JudgeAssignmentError(
-                "Impossible to assign judges, consider reducing your gaps if you"
-                " are making panels, otherwise find some more judges."
-            )
+            # Check if we have enough judges including wing_only judges
+            if len(all_judges) >= num_rounds:
+                raise errors.JudgeAssignmentError(
+                    "Impossible to assign chairs to all rounds. You have enough "
+                    "checked-in judges, but some are marked as wing-only and cannot "
+                    "chair. Either check in more non-wing judges or unmark some "
+                    "wing-only judges to allow them to chair."
+                )
+            else:
+                raise errors.JudgeAssignmentError(
+                    "Impossible to assign judges, consider reducing your gaps if you"
+                    " are making panels, otherwise find some more judges."
+                )
         elif -1 in judge_assignments[:num_rounds]:
             pairing_list = judge_assignments[: len(pairings)]
             bad_pairing = pairings[pairing_list.index(-1)]
-            raise errors.JudgeAssignmentError(
-                "Could not find a judge for: %s" % str(bad_pairing)
-            )
+            # Check if we have enough judges including wing_only judges
+            if len(all_judges) >= num_rounds and len(chairs) < num_rounds:
+                raise errors.JudgeAssignmentError(
+                    "Impossible to assign chairs to all rounds. You have enough "
+                    "checked-in judges, but some are marked as wing-only and cannot "
+                    "chair. Either check in more non-wing judges or unmark some "
+                    "wing-only judges to allow them to chair."
+                )
+            else:
+                raise errors.JudgeAssignmentError(
+                    "Could not find a judge for: %s" % str(bad_pairing)
+                )
         else:
             raise errors.JudgeAssignmentError()
 
     judge_round_joins, chair_by_pairing = [], [None] * num_rounds
-    assigned_judges = set()
+    assigned_judges = set()  # Track assigned judge indices in 'chairs' list
+    assigned_judge_objects = set()  # Track actual Judge objects
     assigned_pairs = set()
-    for pairing_i, padded_judge_i in enumerate(judge_assignments[:num_rounds]):
-        judge_i = padded_judge_i - num_rounds
+    for pairing_i, padded_chair_i in enumerate(judge_assignments[:num_rounds]):
+        chair_i = padded_chair_i - num_rounds
 
         round_obj = pairings[pairing_i]
-        judge = judges[judge_i]
+        chair = chairs[chair_i]
 
-        round_obj.chair = judge
-        chair_by_pairing[pairing_i] = judge_i
-        assigned_judges.add(judge_i)
-        assigned_pairs.add((pairing_i, judge_i))
+        round_obj.chair = chair
+        chair_by_pairing[pairing_i] = chair_i
+        assigned_judges.add(chair_i)
+        assigned_judge_objects.add(chair.id)  # Track by judge ID
+        assigned_pairs.add((pairing_i, chair_i))
         judge_round_joins.append(
-            Round.judges.through(judge=judge, round=round_obj)
+            Round.judges.through(judge=chair, round=round_obj)
         )
 
     Round.objects.bulk_update(pairings, ["chair"])
-    if settings.pair_wings and num_rounds and len(judges) > num_rounds:
-        max_per_round = min(3, len(judges) // num_rounds + 1)
+    if settings.pair_wings and num_rounds and len(all_judges) > num_rounds:
+        max_per_round = min(3, len(all_judges) // num_rounds + 1)
         for _ in range(1, max_per_round):
-            available_indices = [
-                judge_i
-                for judge_i in range(len(judges))
-                if judge_i not in assigned_judges
-            ]
-            if not available_indices:
+            # Build wing pool from all_judges excluding already assigned
+            wing_judges = [j for j in all_judges if j.id not in assigned_judge_objects]
+            if not wing_judges:
                 break
 
-            wing_pool = list(available_indices)
+            wing_pool = list(range(len(wing_judges)))
             pairing_indices = list(range(num_rounds))
             if settings.wing_mode == WingPairingMode.RANDOM:
                 random.shuffle(wing_pool)
                 random.shuffle(pairing_indices)
 
             wing_edges = []
-            for relative_rank, judge_i in enumerate(wing_pool):
-                judge = judges[judge_i]
-                judge_score = judge_scores[judge_i]
+            wing_judge_scores = construct_judge_scores(wing_judges, settings.mode)
+            for relative_rank, wing_judge_i in enumerate(wing_pool):
+                judge = wing_judges[wing_judge_i]
+                judge_score = wing_judge_scores[wing_judge_i]
                 for pairing_i in pairing_indices:
                     pairing = pairings[pairing_i]
                     has_conflict = judge_conflict(
@@ -226,34 +247,32 @@ def add_judges():
                         wing_mode=settings.wing_mode,
                         chair_judge_i=chair_by_pairing[pairing_i],
                         relative_judge_rank=relative_rank,
-                        judge_index=judge_i,
+                        judge_index=wing_judge_i,
                     )
                     if rejudge_sum > 0 and settings.rejudge_penalty > 0:
                         penalty = settings.rejudge_penalty * (1 + 0.1 * judge_score)
                         weight -= penalty * rejudge_sum
 
-                    wing_edges.append((pairing_i, num_rounds + judge_i, weight))
+                    wing_edges.append((pairing_i, num_rounds + wing_judge_i, weight))
 
             if not wing_edges:
                 break
 
             wing_matches = mwmatching.maxWeightMatching(wing_edges, maxcardinality=True)
-            for pairing_i, padded_judge_i in enumerate(wing_matches[:num_rounds]):
-                if padded_judge_i == -1:
+            for pairing_i, padded_wing_judge_i in enumerate(wing_matches[:num_rounds]):
+                if padded_wing_judge_i == -1:
                     continue
-                judge_i = padded_judge_i - num_rounds
-                if judge_i in assigned_judges:
-                    continue
-                if (pairing_i, judge_i) in assigned_pairs:
+                wing_judge_i = padded_wing_judge_i - num_rounds
+                judge = wing_judges[wing_judge_i]
+                if judge.id in assigned_judge_objects:
                     continue
                 judge_round_joins.append(
                     Round.judges.through(
-                        judge=judges[judge_i],
+                        judge=judge,
                         round=pairings[pairing_i],
                     )
                 )
-                assigned_judges.add(judge_i)
-                assigned_pairs.add((pairing_i, judge_i))
+                assigned_judge_objects.add(judge.id)
 
     Round.judges.through.objects.bulk_create(judge_round_joins)
 

--- a/mittab/templates/outrounds/pairing_card.html
+++ b/mittab/templates/outrounds/pairing_card.html
@@ -74,6 +74,9 @@
           <a class="btn-sm btn-light outround-judge-toggle dropdown-toggle{% if pairing.chair == judge %} chair{% endif %}"
              data-toggle="dropdown" href="#">
             {{judge.name}} <small>({{judge.rank}})</small>
+            {% if judge.wing_only %}
+              <span class="badge badge-warning badge-wing-only ml-1">Wing Only</span>
+            {% endif %}
           </a>
           <ul class="dropdown-menu"></ul>
         </span>

--- a/mittab/templates/pairing/_pairing_card.html
+++ b/mittab/templates/pairing/_pairing_card.html
@@ -79,6 +79,9 @@
             {% if rejudge_count > 1 %}
               <span class="badge badge-warning ml-1">({{rejudge_count}})</span>
             {% endif %}
+            {% if judge.wing_only %}
+              <span class="badge badge-warning badge-wing-only ml-1">Wing Only</span>
+            {% endif %}
           </a>
           <ul class="dropdown-menu"></ul>
         </span>

--- a/mittab/templates/pairing/judge_dropdown.html
+++ b/mittab/templates/pairing/judge_dropdown.html
@@ -27,23 +27,32 @@
   {% if not is_outround and current_judge_rejudge_display %}
     <span class="badge badge-warning ml-1">({{current_judge_rejudge_display}})</span>
   {% endif %}
+  {% if current_judge_obj and current_judge_obj.wing_only %}
+      <span class="badge badge-warning badge-wing-only ml-1">Wing Only</span>
+  {% endif %}
 </a>
 <div class="dropdown-divider"></div>
 <h6 class="text-center dropdown-header">Viable Judges Not Paired In</h6>
 {% if is_outround %}
-  {% for judge_name, judge_id, judge_rank in excluded_judges%}
+  {% for judge_name, judge_id, judge_rank, wing_only in excluded_judges%}
   <a href="#" class="dropdown-item judge-assign searchable" judge-id="{{judge_id}}" round-id="{{round_obj.id}}" current-judge-id="{{current_judge_id}}">
     {{judge_name}} - {{judge_rank}}
+    {% if wing_only %}
+      <span class="badge badge-warning badge-wing-only ml-1">Wing Only</span>
+    {% endif %}
   </a>
   {% empty %}
   <a class="dropdown-item">No viable judges</a>
   {% endfor %}
 {% else %}
-  {% for judge_name, judge_id, judge_rank, rejudge_count in excluded_judges%}
+  {% for judge_name, judge_id, judge_rank, rejudge_count, wing_only in excluded_judges%}
   <a href="#" class="dropdown-item judge-assign searchable" judge-id="{{judge_id}}" round-id="{{round_obj.id}}" current-judge-id="{{current_judge_id}}">
     {{judge_name}} - {{judge_rank}}
     {% if rejudge_count %}
       <span class="badge badge-warning ml-1">({{rejudge_count}})</span>
+    {% endif %}
+    {% if wing_only %}
+      <span class="badge badge-warning badge-wing-only ml-1">Wing Only</span>
     {% endif %}
   </a>
   {% empty %}
@@ -54,19 +63,25 @@
 <div class="dropdown-divider"></div>
 <h6 class="text-center dropdown-header">Viable Judges Within Pairing</h6>
 {% if is_outround %}
-  {% for judge_name, judge_id, judge_rank in included_judges%}
+  {% for judge_name, judge_id, judge_rank, wing_only in included_judges%}
   <a href="#" class="dropdown-item judge-assign searchable" judge-id="{{judge_id}}" round-id="{{round_obj.id}}" current-judge-id="{{current_judge_id}}">
     {{judge_name}} - {{judge_rank}}
+    {% if wing_only %}
+      <span class="badge badge-warning badge-wing-only ml-1">Wing Only</span>
+    {% endif %}
   </a>
   {% empty %}
   <a class="dropdown-item">No viable judges</a>
   {% endfor %}
 {% else %}
-  {% for judge_name, judge_id, judge_rank, rejudge_count in included_judges%}
+  {% for judge_name, judge_id, judge_rank, rejudge_count, wing_only in included_judges%}
   <a href="#" class="dropdown-item judge-assign searchable" judge-id="{{judge_id}}" round-id="{{round_obj.id}}" current-judge-id="{{current_judge_id}}">
     {{judge_name}} - {{judge_rank}}
     {% if rejudge_count %}
       <span class="badge badge-warning ml-1">({{rejudge_count}})</span>
+    {% endif %}
+    {% if wing_only %}
+      <span class="badge badge-warning badge-wing-only ml-1">Wing Only</span>
     {% endif %}
   </a>
   {% empty %}


### PR DESCRIPTION
I added wing_only in the assign rejudges feature a few weeks ago. When I added all the new assign judges settings I forgot about this, which meant that "assign_wings" wouldn't assign judges who were set to wing_only. This PR fixed that, and a few other features relating to the agreement between the two feature sets