### PR TITLE
[codex] speed up ci and add ci waiter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,14 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/python:3.10.16-node
+      - image: cimg/python:3.10.16
         environment:
-          TEST_BROWSER: chrome
           MYSQL_PASSWORD: secret
           MITTAB_DB_HOST: 127.0.0.1
           PIPENV_VENV_IN_PROJECT: true
+          MITTAB_FAKE_WEBPACK_LOADER: "1"
+          MITTAB_SKIP_ASSET_BUILD: "1"
+          MITTAB_INITIALIZE_ARGS: --skip-backups
       - image: cimg/mysql:5.7
         environment:
           MYSQL_ROOT_PASSWORD: secret
@@ -25,26 +27,20 @@ jobs:
       - checkout
       - restore_cache:
           key: deps-v3-3.10.16-{{ checksum "Pipfile.lock" }}
-      
+
       - restore_cache:
           keys:
             - test-timing-v1-{{ .Branch }}-{{ .Revision }}
             - test-timing-v1-{{ .Branch }}-
             - test-timing-v1-
       
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - run:
           name: install dependencies
           command: |
-            sudo apt-get update
-            sudo apt-get install -y default-mysql-client
-            python -m pip install --upgrade pip
-            python -m pip install --user pipenv
-            rm -rf .venv
-            pipenv --python 3.10.16
-            pipenv install --dev
-            npm install
+            if [ ! -d .venv ]; then
+              pipenv --python 3.10.16
+            fi
+            pipenv sync --dev
 
       - save_cache:
           paths:
@@ -71,7 +67,7 @@ jobs:
       - run:
           name: run tests
           command: |
-            pipenv run pytest --junitxml=test-reports/junit.xml --cov=mittab --cov-report xml:cov.xml --circleci-parallelize mittab/
+            pipenv run pytest --junitxml=test-reports/junit.xml --cov=mittab --cov-report xml:cov.xml --ignore=mittab/libs/tests/web --circleci-parallelize mittab/
           no_output_timeout: 20m
 
       - save_cache:
@@ -88,6 +84,94 @@ jobs:
 
       - codecov/upload:
           file: ./cov.xml
+  web-tests:
+    docker:
+      - image: cimg/python:3.10.16-browsers
+        environment:
+          TEST_BROWSER: chrome
+          MYSQL_PASSWORD: secret
+          MITTAB_DB_HOST: 127.0.0.1
+          PIPENV_VENV_IN_PROJECT: true
+          MITTAB_FAKE_WEBPACK_LOADER: "1"
+          MITTAB_INITIALIZE_ARGS: --skip-backups
+          MITTAB_SKIP_WEBPACK_BUILD: "1"
+      - image: cimg/mysql:5.7
+        environment:
+          MYSQL_ROOT_PASSWORD: secret
+          MYSQL_DATABASE: mittab
+          MYSQL_ROOT_HOST: 127.0.0.1
+
+    working_directory: ~/repo
+    parallelism: 2
+
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps-v3-3.10.16-{{ checksum "Pipfile.lock" }}
+
+      - restore_cache:
+          keys:
+            - test-timing-v1-{{ .Branch }}-{{ .Revision }}
+            - test-timing-v1-{{ .Branch }}-
+            - test-timing-v1-
+
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - run:
+          name: install dependencies
+          command: |
+            sudo mkdir -p /tmp/disabled-apt-sources
+            sudo find /etc/apt/sources.list.d -maxdepth 1 -type f \
+              -exec mv {} /tmp/disabled-apt-sources/ \;
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends default-mysql-client
+            if [ ! -d .venv ]; then
+              pipenv --python 3.10.16
+            fi
+            pipenv sync --dev
+
+      - save_cache:
+          paths:
+            - .venv
+          key: deps-v3-3.10.16-{{ checksum "Pipfile.lock" }}
+
+      - run:
+          # Our primary container isn't MYSQL so run a sleep command until it's ready.
+          name: Waiting for MySQL to be ready
+          command: |
+            for i in `seq 1 10`;
+            do
+              nc -z 127.0.0.1 3306 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for MySQL && exit 1
+
+      - run:
+          name: setup db
+          command: |
+            pipenv run ./bin/setup password
+
+      - run:
+          name: run web tests
+          command: |
+            pipenv run pytest --junitxml=test-reports/junit.xml --cov=mittab --cov-report xml:cov-web.xml --circleci-parallelize mittab/libs/tests/web/
+          no_output_timeout: 20m
+
+      - save_cache:
+          paths:
+            - .test_durations
+          key: test-timing-v1-{{ .Branch }}-{{ .Revision }}
+
+      - store_test_results:
+          path: test-reports
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
+
+      - codecov/upload:
+          file: ./cov-web.xml
   lint:
     docker:
       - image: cimg/python:3.10.16-node
@@ -97,22 +181,24 @@ jobs:
       - checkout
       - restore_cache:
           key: deps-v3-3.10.16-{{ checksum "Pipfile.lock" }}
+      - restore_cache:
+          key: npm-v1-{{ checksum "package-lock.json" }}
       - run:
           name: install dependencies
           command: |
-            sudo apt-get update
-            sudo apt-get install -y default-mysql-client
-            python -m pip install --upgrade pip
-            python -m pip install --user pipenv
-            # Remove .venv if it exists from cache to avoid version mismatch
-            rm -rf .venv
-            pipenv --python 3.10.16
-            pipenv install --dev
-            npm install
+            if [ ! -d .venv ]; then
+              pipenv --python 3.10.16
+            fi
+            pipenv sync --dev
+            npm ci --prefer-offline --no-audit
       - save_cache:
           paths:
             - .venv
           key: deps-v3-3.10.16-{{ checksum "Pipfile.lock" }}
+      - save_cache:
+          paths:
+            - ~/.npm
+          key: npm-v1-{{ checksum "package-lock.json" }}
       - run:
           name: Lint -- Python
           command: |
@@ -122,25 +208,23 @@ jobs:
           command: npm run lint
   docs:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.10.16
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-docs-dependencies-{{ checksum "docs/requirements.txt" }}
-            - v2-docs-dependencies-
+            - v3-docs-dependencies-{{ checksum "docs/requirements.txt" }}
+            - v3-docs-dependencies-
       - run:
           name: install dependencies
           command: |
-            sudo apt-get update
-            sudo apt-get install -y python3.10-venv
-            python3 -m venv venv
+            python -m venv venv
             . venv/bin/activate
-            pip install -r docs/requirements.txt
+            pip install --disable-pip-version-check -r docs/requirements.txt
       - save_cache:
           paths:
             - ./venv
-          key: v2-docs-dependencies-{{ checksum "docs/requirements.txt" }}
+          key: v3-docs-dependencies-{{ checksum "docs/requirements.txt" }}
       - run:
           name: Build docs
           command: |
@@ -182,5 +266,6 @@ workflows:
     jobs:
       - lint
       - build
+      - web-tests
       - docs
       - docker-build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 - Environment uses `pipenv`. If pipenv misses the local virtualenv, run `source .venv/bin/activate && pipenv ...`; this is not always necessary.
 - Before handing off changes, run `pipenv run pylint mittab` and `npm run lint`.
 - Read failing CI with `gh pr list -R MIT-Tab/mit-tab --json number,title,statusCheckRollup` and CircleCI build logs from the failing `targetUrl`, e.g. `curl -fsSL https://circleci.com/api/v1.1/project/github/MIT-Tab/mit-tab/<build_num>`.
+- To wait for CI, run `bin/wait-for-ci all` or `bin/wait-for-ci '<check name>'` instead of manually polling and sleeping.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.10.16
 ARG DOCTL_VERSION=1.120.0
 
 RUN apt-get update && \
-  apt-get upgrade -y && \
   apt-get install -y vim default-mysql-client openssl curl memcached && \
+  rm -rf /var/lib/apt/lists/* && \
   curl -sSL https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz \
     | tar -xz -C /usr/local/bin doctl
 
@@ -27,10 +27,9 @@ RUN pip install pipenv
 RUN pipenv install --deploy --system
 
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
-RUN apt-get install -y nodejs aptitude
-RUN aptitude install -y npm
+RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
 
-RUN npm install
+RUN npm ci --no-audit
 RUN ./node_modules/.bin/webpack --config webpack.config.js --mode production
 RUN python manage.py collectstatic --noinput
 

--- a/bin/setup
+++ b/bin/setup
@@ -7,7 +7,11 @@ if [ -x "$(command -v mysqladmin)" ]; then
   mysqladmin ping -h $MITTAB_DB_HOST -u root --password=$MYSQL_ROOT_PASSWORD --wait=30
 fi
 python manage.py migrate --noinput
-npm install
-./node_modules/.bin/webpack --config webpack.config.js --mode production
-python manage.py collectstatic --noinput
-python manage.py initialize_tourney --tab-password $1
+if [ "${MITTAB_SKIP_ASSET_BUILD:-0}" != "1" ]; then
+  if [ "${MITTAB_SKIP_WEBPACK_BUILD:-0}" != "1" ]; then
+    eval "${MITTAB_NPM_INSTALL_COMMAND:-npm install}"
+    ./node_modules/.bin/webpack --config webpack.config.js --mode production
+  fi
+  python manage.py collectstatic --noinput
+fi
+python manage.py initialize_tourney --tab-password $1 ${MITTAB_INITIALIZE_ARGS:-}

--- a/bin/wait-for-ci
+++ b/bin/wait-for-ci
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Wait for GitHub PR checks to finish without manual polling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+
+DONE_CHECK_RUN_STATUSES = {"COMPLETED"}
+DONE_STATUS_CONTEXT_STATES = {"SUCCESS", "FAILURE", "ERROR"}
+SUCCESS_CHECK_RUN_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+SUCCESS_STATUS_CONTEXT_STATES = {"SUCCESS"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Poll GitHub PR checks until a named check, or all checks, are done."
+        )
+    )
+    parser.add_argument(
+        "check",
+        help='Check name to wait for, or "all" for every visible PR check.',
+    )
+    parser.add_argument(
+        "target",
+        nargs="?",
+        help="Optional PR number, PR URL, or branch. Defaults to the current branch PR.",
+    )
+    parser.add_argument(
+        "--repo",
+        default="MIT-Tab/mit-tab",
+        help="GitHub repository to query.",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=60,
+        help="Seconds between polls.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=0,
+        help="Maximum seconds to wait. 0 means wait forever.",
+    )
+    return parser.parse_args()
+
+
+def load_pr(target: str | None, repo: str) -> dict:
+    command = ["gh", "pr", "view"]
+    if target:
+        command.append(target)
+    command.extend(["--repo", repo, "--json", "number,headRefName,statusCheckRollup"])
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        sys.exit("gh is required but was not found on PATH")
+    except subprocess.CalledProcessError as exc:
+        sys.exit(exc.stderr.strip() or "failed to load PR checks")
+    return json.loads(result.stdout)
+
+
+def check_name(check: dict) -> str:
+    return check.get("name") or check.get("context") or "<unnamed check>"
+
+
+def is_done(check: dict) -> bool:
+    if check.get("__typename") == "CheckRun":
+        return check.get("status") in DONE_CHECK_RUN_STATUSES
+    return check.get("state") in DONE_STATUS_CONTEXT_STATES
+
+
+def is_success(check: dict) -> bool:
+    if check.get("__typename") == "CheckRun":
+        return check.get("conclusion") in SUCCESS_CHECK_RUN_CONCLUSIONS
+    return check.get("state") in SUCCESS_STATUS_CONTEXT_STATES
+
+
+def summarize(check: dict) -> str:
+    name = check_name(check)
+    if check.get("__typename") == "CheckRun":
+        status = check.get("status", "UNKNOWN")
+        conclusion = check.get("conclusion")
+        suffix = f"/{conclusion}" if conclusion else ""
+        return f"{name}: {status}{suffix}"
+    return f"{name}: {check.get('state', 'UNKNOWN')}"
+
+
+def selected_checks(checks: list[dict], requested: str) -> list[dict]:
+    if requested.lower() == "all":
+        return checks
+
+    exact = [check for check in checks if check_name(check) == requested]
+    if exact:
+        return exact
+
+    requested_lower = requested.lower()
+    return [
+        check
+        for check in checks
+        if requested_lower in check_name(check).lower()
+    ]
+
+
+def main() -> int:
+    args = parse_args()
+    if args.interval < 1:
+        sys.exit("--interval must be at least 1")
+
+    wait_for_all = args.check.lower() == "all"
+    done_signature: tuple[str, ...] | None = None
+    started = time.monotonic()
+    while True:
+        pr = load_pr(args.target, args.repo)
+        checks = selected_checks(pr.get("statusCheckRollup", []), args.check)
+
+        if not checks:
+            print(
+                f"PR #{pr['number']} has no visible checks matching {args.check!r}; "
+                f"checking again in {args.interval}s.",
+                flush=True,
+            )
+            done_signature = None
+        elif all(is_done(check) for check in checks):
+            current_signature = tuple(sorted(check_name(check) for check in checks))
+            if wait_for_all and done_signature != current_signature:
+                done_signature = current_signature
+                print(
+                    f"PR #{pr['number']} visible checks are done; confirming the "
+                    f"check set is stable in {args.interval}s.",
+                    flush=True,
+                )
+            else:
+                failed = [check for check in checks if not is_success(check)]
+                print(f"PR #{pr['number']} checks done:", flush=True)
+                for check in checks:
+                    print(f"  {summarize(check)}", flush=True)
+                return 1 if failed else 0
+        else:
+            pending = [summarize(check) for check in checks if not is_done(check)]
+            print(
+                f"PR #{pr['number']} waiting on {len(pending)} check(s): "
+                + "; ".join(pending),
+                flush=True,
+            )
+            done_signature = None
+
+        if args.timeout and time.monotonic() - started >= args.timeout:
+            sys.exit(f"timed out waiting for {args.check!r}")
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mittab/apps/tab/management/commands/initialize_tourney.py
+++ b/mittab/apps/tab/management/commands/initialize_tourney.py
@@ -41,6 +41,12 @@ class Command(BaseCommand):
                   Disables backup before new tournament",
             action="store_true",
             default=False)
+        parser.add_argument(
+            "--skip-backups",
+            dest="skip_backups",
+            help="Skip backup creation during initialization.",
+            action="store_true",
+            default=False)
 
     def handle(self, *args, **options):
         apda_board_password = (
@@ -49,7 +55,9 @@ class Command(BaseCommand):
             or USER_MODEL.objects.make_random_password(length=16)
         )
 
-        if not options["first_init"]:
+        if options["skip_backups"]:
+            self.stdout.write("Skipping backups.")
+        elif not options["first_init"]:
             self.stdout.write("Backing up the previous tournament data")
             backup_round(btype=BEFORE_NEW_TOURNAMENT)
         else:
@@ -94,5 +102,5 @@ class Command(BaseCommand):
             f"{'board'.ljust(10, ' ')} | "
             f"{apda_board_password.ljust(10, ' ')}"
         )
-        if options["first_init"]:
+        if options["first_init"] and not options["skip_backups"]:
             backup_round(name="initial-tournament", btype=INITIAL)

--- a/mittab/settings.py
+++ b/mittab/settings.py
@@ -128,6 +128,10 @@ WEBPACK_LOADER = {
         "STATS_FILE": os.path.join(BASE_DIR, "webpack-stats.json"),
     }
 }
+if os.environ.get("MITTAB_FAKE_WEBPACK_LOADER") == "1":
+    WEBPACK_LOADER["DEFAULT"]["LOADER_CLASS"] = (
+        "webpack_loader.loaders.FakeWebpackLoader"
+    )
 
 TEMPLATES = [
     {


### PR DESCRIPTION
## What changed
- Add `bin/wait-for-ci` so agents can block on a named PR check or all checks without manual sleep/poll loops.
- Update agent instructions with the CI wait command.
- Reduce CircleCI setup time while keeping lint, docs, Docker build, CodeQL, coverage, non-web tests, and Selenium web tests.
- Split Selenium tests into a dedicated `web-tests` job, use fake webpack bundles for non-web tests, and collect static files without rebuilding webpack for Selenium.
- Add CI-safe initialization knobs for skipping backups and asset/webpack work when the database is fresh.
- Trim Docker build work by removing `apt-get upgrade`, dropping aptitude, and using `npm ci`.

## Benchmark
Final PR run on `a347912` passed all checks. CircleCI long pole is `build` at 3m49s; full visible PR gate including Codecov completed in about 4m20s.

## Validation
- `pipenv run pylint mittab`
- `npm run lint`
- `pipenv run pytest mittab/libs/tests/views/test_initialize_tourney_command.py`
- `bin/wait-for-ci all 533 --interval 60 --timeout 3600`
