### PR TITLE
[codex] Add staff permission presets

### DIFF
--- a/mittab/apps/tab/auth_roles.py
+++ b/mittab/apps/tab/auth_roles.py
@@ -1,6 +1,187 @@
+from urllib.parse import urlsplit
+
+from django.contrib.auth.models import Group
+from django.urls import Resolver404, resolve, reverse
+
 from mittab.apps.tab.models import Round, TabSettings
 
 APDA_BOARD_GROUP_NAME = "APDA Board"
+
+PRESET_FULL_TAB_STAFF = "full_tab_staff"
+PRESET_ADD_SCRATCHES = "add_scratches"
+PRESET_MANAGE_SCRATCHES = "manage_scratches"
+PRESET_CHECKIN_HELPER = "checkin_helper"
+PRESET_DATA_ENTRY_HELPER = "data_entry_helper"
+PRESET_TAB_ASSISTANT = "tab_assistant"
+
+CAP_ADD_SCRATCHES = "add_scratches"
+CAP_VIEW_SCRATCHES = "view_scratches"
+CAP_CHECKINS = "checkins"
+CAP_DATA_ENTRY = "data_entry"
+
+STAFF_PERMISSION_PRESETS = {
+    PRESET_FULL_TAB_STAFF: {
+        "label": "Full power tab staff",
+        "summary": "Unrestricted tab staff access.",
+        "can": [
+            "Access all tab staff pages and workflows.",
+            "Invite staff and manage permission presets.",
+            "Change settings, run pairings, manage scratches, and use admin tools.",
+        ],
+        "cannot": [],
+        "group": None,
+        "capabilities": set(),
+    },
+    PRESET_ADD_SCRATCHES: {
+        "label": "Add scratches",
+        "summary": "One-purpose scratch entry role.",
+        "can": ["Open the Add Scratch page and submit new scratches."],
+        "cannot": [
+            "View existing scratches.",
+            "See whether a submitted scratch already exists.",
+            "Access other tab staff pages.",
+        ],
+        "group": "MIT-TAB: Add scratches",
+        "capabilities": {CAP_ADD_SCRATCHES},
+    },
+    PRESET_MANAGE_SCRATCHES: {
+        "label": "Create and view scratches",
+        "summary": "Scratch entry plus read-only scratch review.",
+        "can": [
+            "Add new scratches.",
+            "View global, team, and judge scratch lists.",
+        ],
+        "cannot": [
+            "Modify or delete existing scratches.",
+            "Access data entry, check-in, settings, or pairing pages.",
+        ],
+        "group": "MIT-TAB: Create and view scratches",
+        "capabilities": {CAP_ADD_SCRATCHES, CAP_VIEW_SCRATCHES},
+    },
+    PRESET_CHECKIN_HELPER: {
+        "label": "Check-in helper",
+        "summary": "Check-in desk role.",
+        "can": [
+            "View the batch check-in page.",
+            "Check in or undo check-ins for teams, judges, and rooms.",
+        ],
+        "cannot": [
+            "Create or edit tournament data.",
+            "View scratches, settings, pairings, or email management.",
+        ],
+        "group": "MIT-TAB: Check-in helper",
+        "capabilities": {CAP_CHECKINS},
+    },
+    PRESET_DATA_ENTRY_HELPER: {
+        "label": "Data entry helper",
+        "summary": "Roster and room data maintenance role.",
+        "can": [
+            "View, create, edit, and delete debaters, teams, schools, judges, and rooms.",
+            "Bulk import teams, judges, and rooms.",
+        ],
+        "cannot": [
+            "View or modify scratches.",
+            "Change check-ins, settings, pairings, rankings, backups, or email management.",
+        ],
+        "group": "MIT-TAB: Data entry helper",
+        "capabilities": {CAP_DATA_ENTRY},
+    },
+    PRESET_TAB_ASSISTANT: {
+        "label": "Tab assistant",
+        "summary": "Data entry plus check-in support.",
+        "can": [
+            "Do everything in Check-in helper.",
+            "Do everything in Data entry helper.",
+        ],
+        "cannot": [
+            "View or modify scratches.",
+            "Change settings, pairings, rankings, backups, or email management.",
+        ],
+        "group": "MIT-TAB: Tab assistant",
+        "capabilities": {CAP_CHECKINS, CAP_DATA_ENTRY},
+    },
+}
+
+STAFF_PRESET_CHOICES = [
+    (preset, config["label"])
+    for preset, config in STAFF_PERMISSION_PRESETS.items()
+]
+
+STAFF_PRESET_GROUP_NAMES = {
+    config["group"]
+    for config in STAFF_PERMISSION_PRESETS.values()
+    if config["group"]
+}
+
+STAFF_PRESET_DETAILS = [
+    {
+        "value": preset,
+        "label": config["label"],
+        "summary": config["summary"],
+        "can": config["can"],
+        "cannot": config["cannot"],
+    }
+    for preset, config in STAFF_PERMISSION_PRESETS.items()
+]
+
+CAPABILITY_ALLOWED_VIEWS = {
+    CAP_ADD_SCRATCHES: {
+        "add_scratch": {"GET", "POST"},
+    },
+    CAP_VIEW_SCRATCHES: {
+        "add_scratches": {"GET", "POST"},
+        "add_scratch": {"GET", "POST"},
+        "view_scratches": {"GET"},
+        "view_scratches_team": {"GET"},
+    },
+    CAP_CHECKINS: {
+        "batch_checkin": {"GET"},
+        "bulk_check_in": {"POST"},
+    },
+    CAP_DATA_ENTRY: {
+        "delete_school": {"GET", "POST"},
+        "delete_debater": {"GET", "POST"},
+        "delete_judge": {"GET", "POST"},
+        "delete_room": {"GET", "POST"},
+        "delete_team": {"GET", "POST"},
+        "enter_debater": {"GET", "POST"},
+        "enter_judge": {"GET", "POST"},
+        "enter_room": {"GET", "POST"},
+        "enter_school": {"GET", "POST"},
+        "enter_team": {"GET", "POST"},
+        "index": {"GET"},
+        "upload_data": {"GET", "POST"},
+        "view_debater": {"GET", "POST"},
+        "view_debaters": {"GET"},
+        "view_judge": {"GET", "POST"},
+        "view_judges": {"GET"},
+        "view_room": {"GET", "POST"},
+        "view_rooms": {"GET"},
+        "view_school": {"GET", "POST"},
+        "view_schools": {"GET"},
+        "view_team": {"GET", "POST"},
+        "view_teams": {"GET"},
+    },
+}
+
+COMMON_RESTRICTED_STAFF_VIEWS = {
+    "403",
+    "404",
+    "500",
+    "admin_logout",
+    "favicon",
+    "logout",
+    "staff_invite_complete",
+    "tournament_logo",
+}
+
+STAFF_PRESET_LANDING_VIEWS = {
+    PRESET_ADD_SCRATCHES: "add_scratch",
+    PRESET_MANAGE_SCRATCHES: "view_scratches",
+    PRESET_CHECKIN_HELPER: "batch_checkin",
+    PRESET_DATA_ENTRY_HELPER: "index",
+    PRESET_TAB_ASSISTANT: "index",
+}
 
 
 def is_apda_board_user(user):
@@ -21,3 +202,94 @@ def is_apda_board_access_open():
     if total_inrounds < 1:
         return False
     return Round.objects.filter(round_number=total_inrounds).exists()
+
+
+def staff_preset_for_user(user):
+    if not user or not user.is_authenticated:
+        return None
+    if user.is_superuser:
+        return PRESET_FULL_TAB_STAFF
+    if not getattr(user, "is_staff", False):
+        return None
+    group_names = set(user.groups.values_list("name", flat=True))
+    for preset, config in STAFF_PERMISSION_PRESETS.items():
+        group_name = config["group"]
+        if group_name and group_name in group_names:
+            return preset
+    return None
+
+
+def staff_capabilities_for_user(user):
+    preset = staff_preset_for_user(user)
+    if not preset:
+        return set()
+    return set(STAFF_PERMISSION_PRESETS[preset]["capabilities"])
+
+
+def user_has_staff_capability(user, capability):
+    if user and user.is_authenticated and user.is_superuser:
+        return True
+    return capability in staff_capabilities_for_user(user)
+
+
+def is_restricted_staff_user(user):
+    return (
+        user
+        and user.is_authenticated
+        and getattr(user, "is_staff", False)
+        and not user.is_superuser
+    )
+
+
+def restricted_staff_landing_url(user):
+    preset = staff_preset_for_user(user)
+    if not preset:
+        return reverse("403")
+    view_name = STAFF_PRESET_LANDING_VIEWS.get(preset, "index")
+    return reverse(view_name)
+
+
+def restricted_staff_can_access_view(user, view_name, method):
+    if not is_restricted_staff_user(user):
+        return True
+    if view_name in COMMON_RESTRICTED_STAFF_VIEWS:
+        return True
+
+    allowed_methods = set()
+    for capability in staff_capabilities_for_user(user):
+        allowed_methods.update(
+            CAPABILITY_ALLOWED_VIEWS.get(capability, {}).get(view_name, set())
+        )
+    return method in allowed_methods
+
+
+def restricted_staff_can_access_path(user, path, method="GET"):
+    if not is_restricted_staff_user(user):
+        return True
+
+    resolved_path = urlsplit(path).path or "/"
+    if resolved_path.startswith(("/static/", "/dynamic-media/")):
+        return True
+
+    try:
+        view_name = resolve(resolved_path).view_name
+    except Resolver404:
+        return False
+    return restricted_staff_can_access_view(user, view_name, method)
+
+
+def apply_staff_permission_preset(user, preset):
+    if preset not in STAFF_PERMISSION_PRESETS:
+        raise ValueError(f"Unknown staff permission preset: {preset}")
+
+    user.is_staff = True
+    user.is_active = True
+    user.is_superuser = preset == PRESET_FULL_TAB_STAFF
+    user.save(update_fields=["is_staff", "is_active", "is_superuser"])
+
+    user.groups.remove(*Group.objects.filter(name__in=STAFF_PRESET_GROUP_NAMES))
+    group_name = STAFF_PERMISSION_PRESETS[preset]["group"]
+    if group_name:
+        group, _created = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+    return user

--- a/mittab/apps/tab/forms.py
+++ b/mittab/apps/tab/forms.py
@@ -34,6 +34,12 @@ class UploadDataForm(forms.Form):
     room_file = forms.FileField(label="Room Data File", required=False)
     scratch_file = forms.FileField(label="Scratch Data File", required=False)
 
+    def __init__(self, *args, **kwargs):
+        allow_scratches = kwargs.pop("allow_scratches", True)
+        super(UploadDataForm, self).__init__(*args, **kwargs)
+        if not allow_scratches:
+            self.fields.pop("scratch_file")
+
 
 class UploadApdaCsvForm(forms.Form):
     file = forms.FileField(label="CSV File")
@@ -59,8 +65,9 @@ class RoomForm(forms.ModelForm):
         entry = "first_entry" in kwargs
         if entry:
             kwargs.pop("first_entry")
+        allow_checkins = kwargs.pop("allow_checkins", True)
         super(RoomForm, self).__init__(*args, **kwargs)
-        if not entry:
+        if not entry and allow_checkins:
             num_rounds = TabSettings.objects.get(key="tot_rounds").value
             try:
                 room = kwargs["instance"]
@@ -112,8 +119,9 @@ class JudgeForm(forms.ModelForm):
         entry = "first_entry" in kwargs
         if entry:
             kwargs.pop("first_entry")
+        allow_checkins = kwargs.pop("allow_checkins", True)
         super(JudgeForm, self).__init__(*args, **kwargs)
-        if not entry:
+        if not entry and allow_checkins:
             num_rounds = TabSettings.objects.get(key="tot_rounds").value
             try:
                 judge = kwargs["instance"]
@@ -185,6 +193,12 @@ class TeamForm(forms.ModelForm):
         required=False
     )
 
+    def __init__(self, *args, **kwargs):
+        allow_checkins = kwargs.pop("allow_checkins", True)
+        super(TeamForm, self).__init__(*args, **kwargs)
+        if not allow_checkins:
+            self.fields.pop("checked_in", None)
+
     def clean_debaters(self):
         data = self.cleaned_data["debaters"]
         if len(data) not in [1, 2]:
@@ -231,6 +245,12 @@ class TeamForm(forms.ModelForm):
 class TeamEntryForm(TeamForm):
     number_scratches = forms.IntegerField(label="How many initial scratches?",
                                           initial=0)
+
+    def __init__(self, *args, **kwargs):
+        allow_initial_scratches = kwargs.pop("allow_initial_scratches", True)
+        super(TeamEntryForm, self).__init__(*args, **kwargs)
+        if not allow_initial_scratches:
+            self.fields.pop("number_scratches")
 
     def clean_debaters(self):
         data = self.cleaned_data["debaters"]

--- a/mittab/apps/tab/middleware.py
+++ b/mittab/apps/tab/middleware.py
@@ -4,9 +4,16 @@ from urllib.parse import urlsplit
 from django.contrib.auth import logout
 from django.contrib.auth.views import LoginView
 from django.http import HttpResponse, JsonResponse
+from django.urls import Resolver404, resolve
 from django.utils.http import url_has_allowed_host_and_scheme
 
-from mittab.apps.tab.auth_roles import is_apda_board_access_open, is_apda_board_user
+from mittab.apps.tab.auth_roles import (
+    is_apda_board_access_open,
+    is_apda_board_user,
+    is_restricted_staff_user,
+    restricted_staff_can_access_view,
+    restricted_staff_landing_url,
+)
 from mittab.apps.tab.helpers import redirect_and_flash_info
 from mittab.apps.tab.public_rankings import get_standings_publication_setting
 from mittab.apps.tab.views.tournament_todo_views import StaffLoginView
@@ -116,13 +123,41 @@ class Login:
             if request.POST:
                 view = StaffLoginView.as_view()
                 return view(request)
-            else:
+            return redirect_and_flash_info(
+                request,
+                "You must be logged in to view that page",
+                path=f"/public/login/?next={request.path}")
+
+        if request.user.is_authenticated and is_restricted_staff_user(request.user):
+            if path.startswith(("/static/", "/dynamic-media/")):
+                return self.get_response(request)
+
+            try:
+                view_name = resolve(path).view_name
+            except Resolver404:
+                view_name = None
+
+            landing_url = restricted_staff_landing_url(request.user)
+            if path == "/" and landing_url != path:
                 return redirect_and_flash_info(
                     request,
-                    "You must be logged in to view that page",
-                    path=f"/public/login/?next={request.path}")
-        else:
-            return self.get_response(request)
+                    "Your staff account has limited access.",
+                    path=landing_url,
+                )
+
+            can_access = restricted_staff_can_access_view(
+                request.user,
+                view_name,
+                request.method,
+            )
+            if not can_access:
+                return redirect_and_flash_info(
+                    request,
+                    "Your staff account does not have access to that page.",
+                    path="/403/",
+                )
+
+        return self.get_response(request)
 
 
 class TournamentStatusCheck:

--- a/mittab/apps/tab/staff_invites.py
+++ b/mittab/apps/tab/staff_invites.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
+from mittab.apps.tab.auth_roles import apply_staff_permission_preset
 from mittab.libs.email_service import EmailService
 from mittab.libs.email_views import build_staff_invite_email
 
@@ -25,21 +26,21 @@ def send_staff_invite_email(request, user):
     return EmailService().send_bulk([email_request])
 
 
-def get_or_create_staff_invite_user(email, username):
+def get_or_create_staff_invite_user(email, username, permission_preset):
     user_model = get_user_model()
     normalized_email = user_model.objects.normalize_email(email).strip()
     existing_user = user_model.objects.filter(email__iexact=normalized_email).first()
 
     if existing_user:
+        apply_staff_permission_preset(existing_user, permission_preset)
         return existing_user, False
 
     user = user_model(
         username=username.strip(),
         email=normalized_email,
-        is_staff=True,
-        is_superuser=True,
         is_active=True,
     )
     user.set_unusable_password()
     user.save()
+    apply_staff_permission_preset(user, permission_preset)
     return user, True

--- a/mittab/apps/tab/templatetags/tags.py
+++ b/mittab/apps/tab/templatetags/tags.py
@@ -4,7 +4,10 @@ from django.urls import reverse
 from django.utils.html import urlize
 from django.utils.safestring import mark_safe
 
-from mittab.apps.tab.auth_roles import is_apda_board_user
+from mittab.apps.tab.auth_roles import (
+    is_apda_board_user,
+    user_has_staff_capability,
+)
 from mittab.apps.tab.helpers import get_redirect_target
 from mittab.apps.tab import logo_utils
 from mittab.apps.tab.models import DEFAULT_TOURNAMENT_NAME, TabSettings
@@ -153,3 +156,8 @@ def favicon_url():
 @register.simple_tag
 def is_apda_board(user):
     return is_apda_board_user(user)
+
+
+@register.simple_tag
+def staff_can(user, capability):
+    return user_has_staff_capability(user, capability)

--- a/mittab/apps/tab/views/debater_views.py
+++ b/mittab/apps/tab/views/debater_views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.utils.text import slugify
 
+from mittab.apps.tab.auth_roles import CAP_DATA_ENTRY, user_has_staff_capability
 from mittab.apps.tab.forms import DebaterForm
 from mittab.apps.tab.helpers import redirect_and_flash_error, \
     redirect_and_flash_success
@@ -101,6 +102,8 @@ def view_debater(request, debater_id):
             "school", "hybrid_school"
         )
         links = []
+        if user_has_staff_capability(request.user, CAP_DATA_ENTRY):
+            links.append((f"/debater/{debater_id}/delete/", "Delete"))
         team_schools = []
         has_hybrid_school = False
         for team in teams:
@@ -146,6 +149,27 @@ def enter_debater(request):
         "form": form,
         "title": "Create Debater:"
     })
+
+
+def delete_debater(request, debater_id):
+    if not user_has_staff_capability(request.user, CAP_DATA_ENTRY):
+        return redirect_and_flash_error(
+            request,
+            "You cannot delete debaters",
+            path="/403/",
+        )
+
+    try:
+        debater_id = int(debater_id)
+        debater = Debater.objects.get(pk=debater_id)
+        debater.delete()
+    except Debater.DoesNotExist:
+        return redirect_and_flash_error(request, "That debater does not exist")
+    except Exception as exc:
+        return redirect_and_flash_error(request, str(exc))
+    return redirect_and_flash_success(request,
+                                      "Debater deleted successfully",
+                                      path="/")
 
 
 def rank_debaters_ajax(request):

--- a/mittab/apps/tab/views/judge_views.py
+++ b/mittab/apps/tab/views/judge_views.py
@@ -8,6 +8,12 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db.models import Q, Max
 from django.utils import timezone
 
+from mittab.apps.tab.auth_roles import (
+    CAP_CHECKINS,
+    CAP_DATA_ENTRY,
+    CAP_VIEW_SCRATCHES,
+    user_has_staff_capability,
+)
 from mittab.apps.tab.forms import JudgeForm, ScratchForm
 from mittab.apps.tab.helpers import redirect_and_flash_error, redirect_and_flash_success
 from mittab.apps.tab.models import *
@@ -229,21 +235,26 @@ def _prepare_written_rfd_plan(rounds, tournament_name):
 def view_judges(request):
     # Get a list of (id,school_name) tuples
     current_round = TabSettings.objects.get(key="cur_round").value - 1
-    checkins = CheckIn.objects.filter(round_number=current_round)
-    checkins_next = CheckIn.objects.filter(round_number=current_round + 1)
-    checked_in_judges = set([c.judge for c in checkins])
-    checked_in_judges_next = set([c.judge for c in checkins_next])
+    include_checkins = user_has_staff_capability(request.user, CAP_CHECKINS)
+    checked_in_judges = set()
+    checked_in_judges_next = set()
+    if include_checkins:
+        checkins = CheckIn.objects.filter(round_number=current_round)
+        checkins_next = CheckIn.objects.filter(round_number=current_round + 1)
+        checked_in_judges = set([c.judge for c in checkins])
+        checked_in_judges_next = set([c.judge for c in checkins_next])
 
     def flags(judge):
         result = 0
-        if judge in checked_in_judges:
-            result |= TabFlags.JUDGE_CHECKED_IN_CUR
-        else:
-            result |= TabFlags.JUDGE_NOT_CHECKED_IN_CUR
-        if judge in checked_in_judges_next:
-            result |= TabFlags.JUDGE_CHECKED_IN_NEXT
-        else:
-            result |= TabFlags.JUDGE_NOT_CHECKED_IN_NEXT
+        if include_checkins:
+            if judge in checked_in_judges:
+                result |= TabFlags.JUDGE_CHECKED_IN_CUR
+            else:
+                result |= TabFlags.JUDGE_NOT_CHECKED_IN_CUR
+            if judge in checked_in_judges_next:
+                result |= TabFlags.JUDGE_CHECKED_IN_NEXT
+            else:
+                result |= TabFlags.JUDGE_NOT_CHECKED_IN_NEXT
 
         if judge.rank < 3.0:
             result |= TabFlags.LOW_RANKED_JUDGE
@@ -267,19 +278,18 @@ def view_judges(request):
         for judge in judges
     ]
 
-    all_flags = [
-        [
+    all_flags = [[
+        TabFlags.LOW_RANKED_JUDGE,
+        TabFlags.MID_RANKED_JUDGE,
+        TabFlags.HIGH_RANKED_JUDGE,
+    ]]
+    if include_checkins:
+        all_flags.insert(0, [
             TabFlags.JUDGE_CHECKED_IN_CUR,
             TabFlags.JUDGE_NOT_CHECKED_IN_CUR,
             TabFlags.JUDGE_CHECKED_IN_NEXT,
             TabFlags.JUDGE_NOT_CHECKED_IN_NEXT,
-        ],
-        [
-            TabFlags.LOW_RANKED_JUDGE,
-            TabFlags.MID_RANKED_JUDGE,
-            TabFlags.HIGH_RANKED_JUDGE,
-        ]
-    ]
+        ])
     filters, _symbol_text = TabFlags.get_filters_and_symbols(all_flags)
     return render(
         request, "common/list_data.html", {
@@ -298,7 +308,11 @@ def view_judge(request, judge_id):
     except Judge.DoesNotExist:
         return redirect_and_flash_error(request, "Judge not found")
     if request.method == "POST":
-        form = JudgeForm(request.POST, instance=judge)
+        form = JudgeForm(
+            request.POST,
+            instance=judge,
+            allow_checkins=user_has_staff_capability(request.user, CAP_CHECKINS),
+        )
         if form.is_valid():
             try:
                 form.save(actor=request.user)
@@ -309,12 +323,19 @@ def view_judge(request, judge_id):
             return redirect_and_flash_success(
                 request, f"Judge {updated_name} updated successfully")
     else:
-        form = JudgeForm(instance=judge)
+        form = JudgeForm(
+            instance=judge,
+            allow_checkins=user_has_staff_capability(request.user, CAP_CHECKINS),
+        )
         judging_rounds = list(Round.objects.filter(judges=judge).select_related(
             "gov_team", "opp_team", "room"))
     base_url = f"/judge/{judge_id}/"
     scratch_url = f"{base_url}scratches/view/"
-    links = [(scratch_url, f"Scratches for {judge.name}")]
+    links = []
+    if user_has_staff_capability(request.user, CAP_DATA_ENTRY):
+        links.append((f"/judge/{judge_id}/delete/", "Delete"))
+    if user_has_staff_capability(request.user, CAP_VIEW_SCRATCHES):
+        links.append((scratch_url, f"Scratches for {judge.name}"))
     return render(
         request, "tab/judge_detail.html", {
             "form": form,
@@ -346,6 +367,23 @@ def enter_judge(request):
         "form": form,
         "title": "Create Judge"
     })
+
+
+def delete_judge(request, judge_id):
+    if not user_has_staff_capability(request.user, CAP_DATA_ENTRY):
+        return redirect_and_flash_error(request, "You cannot delete judges", path="/403/")
+
+    try:
+        judge_id = int(judge_id)
+        judge = Judge.objects.get(pk=judge_id)
+        judge.delete()
+    except Judge.DoesNotExist:
+        return redirect_and_flash_error(request, "That judge does not exist")
+    except Exception as exc:
+        return redirect_and_flash_error(request, str(exc))
+    return redirect_and_flash_success(request,
+                                      "Judge deleted successfully",
+                                      path="/")
 
 
 def add_scratches(request, judge_id, number_scratches):
@@ -433,10 +471,13 @@ def view_scratches(request, judge_id):
             )
             for i in range(len(scratches))
         ]
-    delete_links = [
-        f"/judge/{judge_id}/scratches/delete/{scratches[i].id}"
-        for i in range(len(scratches))
-    ]
+    read_only = not request.user.is_superuser
+    delete_links = [None] * len(scratches)
+    if not read_only:
+        delete_links = [
+            f"/judge/{judge_id}/scratches/delete/{scratches[i].id}"
+            for i in range(len(scratches))
+        ]
     metadata = [
         {
             "created_by": scratch.created_by_display,
@@ -452,6 +493,7 @@ def view_scratches(request, judge_id):
             "forms": list(zip(forms, delete_links, metadata)),
             "data_type": "Scratch",
             "links": links,
+            "read_only": read_only,
             "title": f"Viewing Scratch Information for {judge.name}"
         })
 

--- a/mittab/apps/tab/views/staff_invite_views.py
+++ b/mittab/apps/tab/views/staff_invite_views.py
@@ -4,6 +4,11 @@ from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth.views import PasswordResetCompleteView, PasswordResetConfirmView
 from django.shortcuts import redirect, render, reverse
 
+from mittab.apps.tab.auth_roles import (
+    PRESET_FULL_TAB_STAFF,
+    STAFF_PRESET_CHOICES,
+    STAFF_PRESET_DETAILS,
+)
 from mittab.apps.tab.helpers import redirect_and_flash_error, redirect_and_flash_success
 from mittab.apps.tab.staff_invites import (
     get_or_create_staff_invite_user,
@@ -26,12 +31,22 @@ class StaffInviteForm(forms.Form):
             "existing staff account, enter that account's current username."
         ),
     )
+    permission_preset = forms.ChoiceField(
+        label="Permission preset",
+        choices=STAFF_PRESET_CHOICES,
+        initial=PRESET_FULL_TAB_STAFF,
+        required=False,
+        help_text=(
+            "Choose the narrowest role this staffer needs. Only full power "
+            "tab staff can access the entire admin surface."
+        ),
+    )
 
     def clean_email(self):
         User = get_user_model()
         email = User.objects.normalize_email(self.cleaned_data["email"]).strip()
         user = User.objects.filter(email__iexact=email).first()
-        if user and (not user.is_staff or not user.is_superuser):
+        if user and not user.is_staff:
             raise forms.ValidationError(
                 "A non-staff account already uses this email. Update it in "
                 "the admin interface before sending an invite."
@@ -75,6 +90,9 @@ class StaffInviteForm(forms.Form):
             raise forms.ValidationError(exc.messages) from exc
         return username
 
+    def clean_permission_preset(self):
+        return self.cleaned_data["permission_preset"] or PRESET_FULL_TAB_STAFF
+
 
 @user_passes_test(is_superuser, login_url="/403/")
 def invite_staff(request):
@@ -84,8 +102,9 @@ def invite_staff(request):
             user, _created = get_or_create_staff_invite_user(
                 form.cleaned_data["email"],
                 form.cleaned_data["username"],
+                form.cleaned_data["permission_preset"],
             )
-            if not user.is_staff or not user.is_superuser:
+            if not user.is_staff:
                 return redirect_and_flash_error(
                     request,
                     "A non-staff account already uses this email. Update it in "
@@ -114,6 +133,7 @@ def invite_staff(request):
         {
             "title": "Invite Tab Staff",
             "form": form,
+            "staff_preset_details": STAFF_PRESET_DETAILS,
         },
     )
 

--- a/mittab/apps/tab/views/team_views.py
+++ b/mittab/apps/tab/views/team_views.py
@@ -3,6 +3,13 @@ from django.contrib.auth.decorators import permission_required
 from django.shortcuts import render
 from django.utils.text import slugify
 
+from mittab.apps.tab.auth_roles import (
+    CAP_ADD_SCRATCHES,
+    CAP_CHECKINS,
+    CAP_DATA_ENTRY,
+    CAP_VIEW_SCRATCHES,
+    user_has_staff_capability,
+)
 from mittab.apps.tab.forms import TeamForm, TeamEntryForm, ScratchForm
 from mittab.libs.cacheing import cache_logic
 from mittab.libs.errors import *
@@ -18,7 +25,11 @@ from mittab.libs.tab_logic import rankings
 
 
 def view_teams(request):
+    include_checkins = user_has_staff_capability(request.user, CAP_CHECKINS)
+
     def flags(team):
+        if not include_checkins:
+            return 0
         result = 0
         if team.checked_in:
             result |= TabFlags.TEAM_CHECKED_IN
@@ -36,8 +47,10 @@ def view_teams(request):
         )
         for team in Team.objects.prefetch_related("ranking_groups").all()
     ]
-    all_flags = [[TabFlags.TEAM_CHECKED_IN, TabFlags.TEAM_NOT_CHECKED_IN]]
-    filters, symbol_text = TabFlags.get_filters_and_symbols(all_flags)
+    filters, symbol_text = [], ""
+    if include_checkins:
+        all_flags = [[TabFlags.TEAM_CHECKED_IN, TabFlags.TEAM_NOT_CHECKED_IN]]
+        filters, symbol_text = TabFlags.get_filters_and_symbols(all_flags)
     return render(
         request, "common/list_data.html", {
             "item_type": "team",
@@ -63,7 +76,11 @@ def view_team(request, team_id):
     except Team.DoesNotExist:
         return redirect_and_flash_error(request, "Team not found")
     if request.method == "POST":
-        form = TeamForm(request.POST, instance=team)
+        form = TeamForm(
+            request.POST,
+            instance=team,
+            allow_checkins=user_has_staff_capability(request.user, CAP_CHECKINS),
+        )
         if form.is_valid():
             try:
                 form.save(actor=request.user)
@@ -75,13 +92,18 @@ def view_team(request, team_id):
             return redirect_and_flash_success(
                 request, f"Team {updated_name} updated successfully")
     else:
-        form = TeamForm(instance=team)
-        links = [
-            (
+        form = TeamForm(
+            instance=team,
+            allow_checkins=user_has_staff_capability(request.user, CAP_CHECKINS),
+        )
+        links = []
+        if user_has_staff_capability(request.user, CAP_DATA_ENTRY):
+            links.append((f"/team/{team_id}/delete/", "Delete"))
+        if user_has_staff_capability(request.user, CAP_VIEW_SCRATCHES):
+            links.append((
                 f"/team/{team_id}/scratches/view/",
                 f"Scratches for {team.display_backend}",
-            )
-        ]
+            ))
         return render(
             request, "tab/team_detail.html", {
                 "title": f"Viewing Team: {team.display_backend}",
@@ -96,8 +118,17 @@ def view_team(request, team_id):
 
 
 def enter_team(request):
+    allow_initial_scratches = (
+        user_has_staff_capability(request.user, CAP_ADD_SCRATCHES) or
+        user_has_staff_capability(request.user, CAP_VIEW_SCRATCHES)
+    )
+    allow_checkins = user_has_staff_capability(request.user, CAP_CHECKINS)
     if request.method == "POST":
-        form = TeamEntryForm(request.POST)
+        form = TeamEntryForm(
+            request.POST,
+            allow_initial_scratches=allow_initial_scratches,
+            allow_checkins=allow_checkins,
+        )
         if form.is_valid():
             try:
                 team = form.save(actor=request.user)
@@ -106,7 +137,7 @@ def enter_team(request):
                     request,
                     "Team name cannot be validated, most likely a duplicate school"
                 )
-            num_forms = form.cleaned_data["number_scratches"]
+            num_forms = form.cleaned_data.get("number_scratches", 0)
             if num_forms > 0:
                 return HttpResponseRedirect(
                     f"/team/{team.pk}/scratches/add/{num_forms}"
@@ -118,11 +149,31 @@ def enter_team(request):
                     f"Team {team_name} created successfully",
                     path="/")
     else:
-        form = TeamEntryForm()
+        form = TeamEntryForm(
+            allow_initial_scratches=allow_initial_scratches,
+            allow_checkins=allow_checkins,
+        )
     return render(request, "common/data_entry.html", {
         "form": form,
         "title": "Create Team"
     })
+
+
+def delete_team(request, team_id):
+    if not user_has_staff_capability(request.user, CAP_DATA_ENTRY):
+        return redirect_and_flash_error(request, "You cannot delete teams", path="/403/")
+
+    try:
+        team_id = int(team_id)
+        team = Team.objects.get(pk=team_id)
+        team.delete()
+    except Team.DoesNotExist:
+        return redirect_and_flash_error(request, "That team does not exist")
+    except Exception as exc:
+        return redirect_and_flash_error(request, str(exc))
+    return redirect_and_flash_success(request,
+                                      "Team deleted successfully",
+                                      path="/")
 
 
 def add_scratches(request, team_id, number_scratches):
@@ -214,10 +265,13 @@ def view_scratches(request, team_id):
             )
             for i in range(len(scratches))
         ]
-    delete_links = [
-        f"/team/{team_id}/scratches/delete/{scratches[i].id}"
-        for i in range(len(scratches))
-    ]
+    read_only = not request.user.is_superuser
+    delete_links = [None] * len(scratches)
+    if not read_only:
+        delete_links = [
+            f"/team/{team_id}/scratches/delete/{scratches[i].id}"
+            for i in range(len(scratches))
+        ]
     metadata = [
         {
             "created_by": scratch.created_by_display,
@@ -232,6 +286,7 @@ def view_scratches(request, team_id):
             "forms": list(zip(forms, delete_links, metadata)),
             "data_type": "Scratch",
             "links": links,
+            "read_only": read_only,
             "title": f"Viewing Scratch Information for {team.display_backend}"
         })
 

--- a/mittab/apps/tab/views/tournament_todo_views.py
+++ b/mittab/apps/tab/views/tournament_todo_views.py
@@ -2,6 +2,11 @@ from django.contrib.auth.views import LoginView
 from django.http import JsonResponse
 from django.shortcuts import redirect, render, reverse
 
+from mittab.apps.tab.auth_roles import (
+    is_restricted_staff_user,
+    restricted_staff_can_access_path,
+    restricted_staff_landing_url,
+)
 from mittab.apps.tab.helpers import redirect_and_flash_success
 from mittab.apps.tab.models import UserTournamentSetupPreference
 from mittab.libs.tournament_todo import (
@@ -25,7 +30,14 @@ class StaffLoginView(LoginView):
     def get_success_url(self):
         redirect_url = self.get_redirect_url()
         if redirect_url:
+            if is_restricted_staff_user(self.request.user):
+                if restricted_staff_can_access_path(self.request.user, redirect_url):
+                    return redirect_url
+                return restricted_staff_landing_url(self.request.user)
             return redirect_url
+
+        if is_restricted_staff_user(self.request.user):
+            return restricted_staff_landing_url(self.request.user)
 
         preference, _ = UserTournamentSetupPreference.objects.get_or_create(
             user=self.request.user,

--- a/mittab/apps/tab/views/views.py
+++ b/mittab/apps/tab/views/views.py
@@ -1,5 +1,5 @@
 import os
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
@@ -11,7 +11,14 @@ from django.core.management import call_command
 import yaml
 
 from mittab.apps.tab.archive import ArchiveExporter
-from mittab.apps.tab.auth_roles import is_apda_board_user
+from mittab.apps.tab.auth_roles import (
+    CAP_ADD_SCRATCHES,
+    CAP_CHECKINS,
+    CAP_DATA_ENTRY,
+    CAP_VIEW_SCRATCHES,
+    is_apda_board_user,
+    user_has_staff_capability,
+)
 from mittab.apps.tab.black_rod_bundle import BlackRodBundleExporter
 from mittab.apps.tab.views.debater_views import get_speaker_rankings
 from mittab.apps.tab.forms import (
@@ -320,14 +327,29 @@ def render_500(request, *args, **kwargs):
 def add_scratch(request):
     if request.method == "POST":
         form = ScratchForm(request.POST)
+        can_view_scratches = user_has_staff_capability(
+            request.user,
+            CAP_VIEW_SCRATCHES,
+        )
         if form.is_valid():
             try:
-                form.save(actor=request.user)
+                with transaction.atomic():
+                    form.save(actor=request.user)
             except IntegrityError:
+                if not can_view_scratches:
+                    return redirect_and_flash_success(
+                        request,
+                        "Scratch submitted.",
+                        path=reverse("add_scratch"),
+                    )
                 return redirect_and_flash_error(request,
                                                 "This scratch already exists.")
-        return redirect_and_flash_success(request,
-                                          "Scratch created successfully")
+        success_path = reverse("add_scratch") if not can_view_scratches else None
+        return redirect_and_flash_success(
+            request,
+            "Scratch created successfully",
+            path=success_path,
+        )
     else:
         form = ScratchForm(initial={"scratch_type": 0})
     return render(request, "common/data_entry.html", {
@@ -413,8 +435,10 @@ def enter_school(request):
     })
 
 
-@permission_required("tab.school.can_delete", login_url="/403/")
 def delete_school(request, school_id):
+    if not user_has_staff_capability(request.user, CAP_DATA_ENTRY):
+        return redirect("/403/")
+
     error_msg = None
     try:
         school_id = int(school_id)
@@ -468,7 +492,11 @@ def view_room(request, room_id):
     except Room.DoesNotExist:
         return redirect_and_flash_error(request, "Room not found")
     if request.method == "POST":
-        form = RoomForm(request.POST, instance=room)
+        form = RoomForm(
+            request.POST,
+            instance=room,
+            allow_checkins=user_has_staff_capability(request.user, CAP_CHECKINS),
+        )
         if form.is_valid():
             try:
                 form.save()
@@ -481,7 +509,10 @@ def view_room(request, room_id):
             return redirect_and_flash_success(
                 request, f"School {updated_name} updated successfully")
     else:
-        form = RoomForm(instance=room)
+        form = RoomForm(
+            instance=room,
+            allow_checkins=user_has_staff_capability(request.user, CAP_CHECKINS),
+        )
 
         # Get all rounds that happened in this room with related judges
         rounds = Round.objects.filter(room=room).select_related(
@@ -493,11 +524,28 @@ def view_room(request, room_id):
 
     return render(request, "tab/room_detail.html", {
         "form": form,
-        "links": [],
+        "links": [(f"/room/{room_id}/delete/", "Delete")],
         "room_rounds": rounds,
         "room_outrounds": outrounds,
         "title": f"Viewing Room: {room.name}"
     })
+
+
+def delete_room(request, room_id):
+    if not user_has_staff_capability(request.user, CAP_DATA_ENTRY):
+        return redirect("/403/")
+
+    try:
+        room_id = int(room_id)
+        room = Room.objects.get(pk=room_id)
+        room.delete()
+    except Room.DoesNotExist:
+        return redirect_and_flash_error(request, "That room does not exist")
+    except Exception as e:
+        return redirect_and_flash_error(request, str(e))
+    return redirect_and_flash_success(request,
+                                      "Room deleted successfully",
+                                      path="/")
 
 
 def enter_room(request):
@@ -722,10 +770,18 @@ def upload_data(request):
     team_info = {"errors": [], "uploaded": False}
     judge_info = {"errors": [], "uploaded": False}
     room_info = {"errors": [], "uploaded": False}
-    scratch_info = {"errors": [], "uploaded": False}
+    allow_scratch_import = (
+        user_has_staff_capability(request.user, CAP_ADD_SCRATCHES) or
+        user_has_staff_capability(request.user, CAP_VIEW_SCRATCHES)
+    )
+    scratch_info = {"errors": [], "uploaded": False} if allow_scratch_import else None
 
     if request.method == "POST":
-        form = UploadDataForm(request.POST, request.FILES)
+        form = UploadDataForm(
+            request.POST,
+            request.FILES,
+            allow_scratches=allow_scratch_import,
+        )
         if form.is_valid():
             if "team_file" in request.FILES:
                 team_info["errors"] = import_teams.import_teams(
@@ -739,17 +795,18 @@ def upload_data(request):
                 room_info["errors"] = import_rooms.import_rooms(
                     request.FILES["room_file"])
                 room_info["uploaded"] = True
-            if "scratch_file" in request.FILES:
+            if allow_scratch_import and "scratch_file" in request.FILES:
                 scratch_info["errors"] = import_scratches.import_scratches(
                     request.FILES["scratch_file"], created_by=request.user)
                 scratch_info["uploaded"] = True
 
+        scratch_errors = scratch_info["errors"] if scratch_info else []
         if not team_info["errors"] + judge_info["errors"] + \
-                room_info["errors"] + scratch_info["errors"]:
+                room_info["errors"] + scratch_errors:
             return redirect_and_flash_success(request,
                                               "Data imported successfully")
     else:
-        form = UploadDataForm()
+        form = UploadDataForm(allow_scratches=allow_scratch_import)
     return render(
         request, "common/data_upload.html", {
             "form": form,

--- a/mittab/libs/tests/views/test_staff_invites.py
+++ b/mittab/libs/tests/views/test_staff_invites.py
@@ -7,6 +7,10 @@ from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 
+from mittab.apps.tab.auth_roles import (
+    PRESET_DATA_ENTRY_HELPER,
+    STAFF_PERMISSION_PRESETS,
+)
 from mittab.libs.tournament_todo import get_tournament_todo_steps
 
 
@@ -109,6 +113,31 @@ class TestStaffInvites(TestCase):
         self.assertEqual(email_request.to_address, existing_user.email)
 
     @patch("mittab.apps.tab.staff_invites.EmailService")
+    def test_invite_can_assign_limited_permission_preset(self, email_service):
+        email_service.return_value.send_bulk.return_value = 1
+
+        response = self.client.post(
+            reverse("invite_staff"),
+            {
+                "email": "data.entry@example.com",
+                "username": "data_entry",
+                "permission_preset": PRESET_DATA_ENTRY_HELPER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        invited_user = get_user_model().objects.get(email="data.entry@example.com")
+        self.assertTrue(invited_user.is_staff)
+        self.assertFalse(invited_user.is_superuser)
+        self.assertTrue(
+            invited_user.groups.filter(
+                name=STAFF_PERMISSION_PRESETS[
+                    PRESET_DATA_ENTRY_HELPER
+                ]["group"],
+            ).exists()
+        )
+
+    @patch("mittab.apps.tab.staff_invites.EmailService")
     def test_invite_rejects_existing_non_staff_account(self, email_service):
         get_user_model().objects.create_user(
             username="entry",
@@ -171,6 +200,20 @@ class TestStaffInvites(TestCase):
         response = self.client.get(reverse("invite_staff"))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(urlparse(response["Location"]).path, "/403/")
+
+    def test_invite_page_explains_permission_presets(self):
+        response = self.client.get(reverse("invite_staff"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Permission Presets")
+        self.assertContains(response, "One-purpose scratch entry role.")
+        self.assertContains(response, "Check-in desk role.")
+        self.assertContains(
+            response,
+            "View, create, edit, and delete debaters, teams, schools, "
+            "judges, and rooms.",
+        )
+        self.assertContains(response, "Change settings, pairings, rankings, backups")
 
     def _invite_path_from_email(self, text_body):
         match = re.search(r"https?://[^\s]+", text_body)

--- a/mittab/libs/tests/views/test_tab_views.py
+++ b/mittab/libs/tests/views/test_tab_views.py
@@ -2,6 +2,7 @@ import re
 from decimal import Decimal
 from datetime import timedelta
 from unittest import mock
+from urllib.parse import urlparse
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -29,6 +30,14 @@ from mittab.apps.tab.models import (
     WrittenRFDEmailLog,
     Scratch,
     AuditEvent,
+)
+from mittab.apps.tab.auth_roles import (
+    PRESET_ADD_SCRATCHES,
+    PRESET_CHECKIN_HELPER,
+    PRESET_DATA_ENTRY_HELPER,
+    PRESET_MANAGE_SCRATCHES,
+    PRESET_TAB_ASSISTANT,
+    apply_staff_permission_preset,
 )
 from mittab.libs.email_service import EmailServiceError
 from mittab.apps.tab.views.judge_views import EMAIL_RATE_LIMIT_WINDOW
@@ -133,6 +142,190 @@ class TestTabViews(TestCase):
                 f"Failed to render {url}, got status {response.status_code}")
             self.assertIn(expected_content, response.content.decode(),
                 f"Expected content '{expected_content}' not found in {url}")
+
+    def test_add_scratches_preset_only_adds_scratches_without_duplicate_leak(self):
+        self._login_with_staff_preset(PRESET_ADD_SCRATCHES)
+        team = Team.objects.first()
+        judge = Judge.objects.first()
+        Scratch.objects.get_or_create(
+            team=team,
+            judge=judge,
+            defaults={"scratch_type": Scratch.TEAM_SCRATCH},
+        )
+
+        response = self.client.get(reverse("add_scratch"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Add Scratch")
+
+        response = self.client.get(reverse("view_scratches"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response["Location"]).path, "/403/")
+
+        response = self.client.post(
+            reverse("add_scratch"),
+            {
+                "team": team.id,
+                "judge": judge.id,
+                "scratch_type": Scratch.TEAM_SCRATCH,
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "This scratch already exists")
+
+    def test_create_and_view_scratches_preset_cannot_modify_existing_scratches(self):
+        self._login_with_staff_preset(PRESET_MANAGE_SCRATCHES)
+        team = Team.objects.first()
+        judge = Judge.objects.first()
+        Scratch.objects.get_or_create(
+            team=team,
+            judge=judge,
+            defaults={"scratch_type": Scratch.TEAM_SCRATCH},
+        )
+
+        response = self.client.get(reverse("view_scratches"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Viewing All Scratches")
+
+        response = self.client.get(reverse("view_scratches_team", args=[team.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Viewing Scratch Information")
+        self.assertContains(response, "fieldset disabled")
+        self.assertNotContains(response, "btn-outline-danger")
+
+        response = self.client.post(
+            reverse("view_scratches_team", args=[team.id]),
+            {
+                "1-team": team.id,
+                "1-judge": judge.id,
+                "1-scratch_type": Scratch.TAB_SCRATCH,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response["Location"]).path, "/403/")
+
+    def test_checkin_helper_preset_only_allows_checkin_pages(self):
+        self._login_with_staff_preset(PRESET_CHECKIN_HELPER)
+        team = Team.objects.first()
+
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response["Location"]).path, reverse("batch_checkin"))
+
+        response = self.client.get(reverse("batch_checkin"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Batch Check-In")
+
+        response = self.client.post(
+            reverse("bulk_check_in"),
+            {
+                "entity_type": "team",
+                "action": "check_in",
+                "entity_ids[]": [str(team.id)],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+
+        response = self.client.get(reverse("settings_form"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response["Location"]).path, "/403/")
+
+    def test_data_entry_helper_preset_excludes_scratches_checkins_and_pairing(self):
+        self._login_with_staff_preset(PRESET_DATA_ENTRY_HELPER)
+        school = School.objects.create(name="Delete Me")
+        team = Team.objects.first()
+
+        response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Schools")
+        self.assertNotContains(response, "Email Management")
+        self.assertNotContains(response, "Manage Ranking Groups")
+
+        response = self.client.get(reverse("enter_team"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "How many initial scratches?")
+        self.assertNotContains(response, "Checked in")
+
+        response = self.client.get(reverse("view_team", args=[team.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Scratches for")
+        self.assertNotContains(response, "View Tab Card")
+
+        response = self.client.get(reverse("upload_data"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Scratch Data File")
+
+        response = self.client.get(reverse("delete_school", args=[school.id]))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(School.objects.filter(id=school.id).exists())
+
+        for url in [
+                reverse("batch_checkin"),
+                reverse("settings_form"),
+                reverse("view_scratches")]:
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(urlparse(response["Location"]).path, "/403/")
+
+    def test_tab_assistant_combines_checkin_and_data_entry_without_scratches(self):
+        self._login_with_staff_preset(PRESET_TAB_ASSISTANT)
+
+        response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse("batch_checkin"))
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(reverse("view_scratches"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response["Location"]).path, "/403/")
+
+    def test_restricted_staff_login_redirects_to_accessible_landing_page(self):
+        user = self._create_staff_preset_user(PRESET_ADD_SCRATCHES)
+        self.client.logout()
+
+        response = self.client.post(
+            reverse("tab_login"),
+            {
+                "username": user.username,
+                "password": "presetpass123",
+                "next": reverse("settings_form"),
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response["Location"]).path, reverse("add_scratch"))
+
+    def test_restricted_staff_login_honors_accessible_next_page(self):
+        user = self._create_staff_preset_user(PRESET_CHECKIN_HELPER)
+        self.client.logout()
+
+        response = self.client.post(
+            reverse("tab_login"),
+            {
+                "username": user.username,
+                "password": "presetpass123",
+                "next": reverse("batch_checkin"),
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response["Location"]).path, reverse("batch_checkin"))
+
+    def _login_with_staff_preset(self, preset):
+        user = self._create_staff_preset_user(preset)
+        self.client.force_login(user)
+        return user
+
+    def _create_staff_preset_user(self, preset):
+        self.client.logout()
+        user = get_user_model().objects.create_user(
+            username=f"{preset}_user",
+            password="presetpass123",
+            email=f"{preset}@example.com",
+        )
+        apply_staff_permission_preset(user, preset)
+        return user
 
     def test_staff_ballot_view_allows_editing_submitted_ballot(self):
         round_obj = Round.objects.filter(round_number=1).first()

--- a/mittab/templates/base/_navigation.html
+++ b/mittab/templates/base/_navigation.html
@@ -63,6 +63,10 @@
 {% public_display_flags as public_display_flags %}
 {% motions_enabled as motions_enabled_flag %}
 {% is_apda_board user as is_apda_board_user %}
+{% staff_can user "add_scratches" as can_add_scratches %}
+{% staff_can user "view_scratches" as can_view_scratches %}
+{% staff_can user "checkins" as can_checkins %}
+{% staff_can user "data_entry" as can_data_entry %}
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm mittab-nav">
   <div class="container w-95">
@@ -87,6 +91,7 @@
       </ul>
       {% else %}
       <ul class="navbar-nav mr-auto order-0">
+        {% if user.is_superuser %}
         <li class="nav-item dropdown">
           <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request pair_round %}{% active request view_status %}{% active request view_rounds %}">
             Pairings
@@ -122,17 +127,25 @@
             <a class="dropdown-item {% active request download_black_rod_bundle %}" href="{{ download_black_rod_bundle|with_return_to }}" title="Export a tournament bundle for Black Rod ingest.">Export Black-Rod Bundle</a>
           </div>
         </li>
+        {% endif %}
 
+        {% if can_add_scratches or can_view_scratches %}
         <li class="nav-item dropdown">
           <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request view_scratches %}{% active request add_scratch %}">
             Scratches
           </a>
           <div class="dropdown-menu">
+            {% if can_view_scratches %}
             <a class="dropdown-item {%active request view_scratches %}" href="{{ view_scratches|with_return_to }}">View Scratches</a>
+            {% endif %}
+            {% if can_add_scratches %}
             <a class="dropdown-item {%active request add_scratch %}" href="{{ add_scratch|with_return_to }}">Add Scratch</a>
+            {% endif %}
           </div>
         </li>
+        {% endif %}
 
+        {% if user.is_superuser %}
         <li class="nav-item dropdown">
           <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request settings_form %}{% active request public_homepage_admin %}{% active request public_rankings_control %}{% active request tournament_todo %}{% active request invite_staff %}{% active request email_management %}{% active request registration_admin %}{% active request manage_motions %}">
             Setup
@@ -150,20 +163,30 @@
             {% endif %}
           </div>
         </li>
+        {% endif %}
 
+        {% if user.is_superuser or can_checkins or can_data_entry %}
         <li class="nav-item dropdown">
           <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request batch_checkin %}{% active request upload_data %}{% active request confirm_start_new_tourny %}">
             Admin
           </a>
           <div class="dropdown-menu">
+            {% if can_checkins %}
             <a class="dropdown-item {% active request batch_checkin %}" href="{{ batch_checkin|with_return_to }}">Batch Checkin</a>
+            {% endif %}
+            {% if can_data_entry %}
             <a class="dropdown-item {% active request upload_data %}" href="{{ upload_data|with_return_to }}">Bulk Data Upload</a>
+            {% endif %}
+            {% if user.is_superuser %}
             <a class="dropdown-item {% active request confirm_start_new_tourney %}" href="{{ confirm_start_new_tourny|with_return_to }}">New Tournament</a>
             <a class="dropdown-item" href="/admin">Admin Interface</a>
+            {% endif %}
           </div>
         </li>
+        {% endif %}
       </ul>
       <ul class="navbar-nav ml-auto">
+        {% if user.is_superuser %}
         <li class="nav-item dropdown">
           <a data-toggle="dropdown" class="nav-link dropdown-toggle {% active request public_pairings %}{% active request public_missing_ballots %}{% active request public_eballot %}{% active request public_team_portal %}{% active request public_judges %}{% active request public_teams %}{% active request public_outround_varsity %}{% active request public_outround_novice %}{% active request public_motions %}">
             Public
@@ -191,6 +214,7 @@
             <a class="dropdown-item {% active request public_outround_novice %}" href="{{ public_outround_novice|with_return_to }}">Novice Outrounds</a>
           </div>
         </li>
+        {% endif %}
         <li class="nav-item">
           <a class="nav-link" href="{{ logout|with_return_to }}">Logout</a>
         </li>

--- a/mittab/templates/common/_index_list.html
+++ b/mittab/templates/common/_index_list.html
@@ -38,17 +38,17 @@
   </h4>
   <div class="collapse show" id="{{ html_id }}-content">
     <div class="index-section-content">
-      {% if model_name == "Teams" %}
+      {% if user.is_superuser and model_name == "Teams" %}
         <div class="text-center mb-2">
           <a href="{% url 'manage_ranking_groups' %}" class="btn btn-sm btn-light">Manage Ranking Groups</a>
         </div>
       {% endif %}
-      {% if model_name == "Rooms" %}
+      {% if user.is_superuser and model_name == "Rooms" %}
         <div class="text-center mb-2">
           <a href="{% url 'manage_room_tags' %}" class="btn btn-sm btn-light">Manage Room Tags</a>
         </div>
       {% endif %}
-      {% if view_path_prefix == "judge" %}
+      {% if user.is_superuser and view_path_prefix == "judge" %}
         <div class="text-center mb-2">
           <a class="btn btn-sm btn-light" href="{% url 'email_management' %}">
             Email Management

--- a/mittab/templates/common/data_entry_multiple.html
+++ b/mittab/templates/common/data_entry_multiple.html
@@ -41,14 +41,20 @@
           {% endif %}
         </div>
         {% endif %}
-        {% bootstrap_form form %}
+        {% if read_only %}
+          <fieldset disabled>
+            {% bootstrap_form form %}
+          </fieldset>
+        {% else %}
+          {% bootstrap_form form %}
+        {% endif %}
       </div>
     </div>
     {% endfor %}
 
     {% return_to_input %}
 
-    {% if forms %}
+    {% if forms and not read_only %}
     <input type="submit" class="btn btn-primary" value="Submit"/>
     {% else %}
     <p class="text-center lead">No scratches</p>

--- a/mittab/templates/common/data_upload.html
+++ b/mittab/templates/common/data_upload.html
@@ -18,9 +18,11 @@
     {% include "common/_upload_error.html" %}
   {% endwith %}
 
-  {% with obj_type="scratch" info_obj=scratch_info %}
-    {% include "common/_upload_error.html" %}
-  {% endwith %}
+  {% if scratch_info %}
+    {% with obj_type="scratch" info_obj=scratch_info %}
+      {% include "common/_upload_error.html" %}
+    {% endwith %}
+  {% endif %}
 
   <p class="text-center">
     Check out

--- a/mittab/templates/tab/debater_detail.html
+++ b/mittab/templates/tab/debater_detail.html
@@ -4,6 +4,7 @@
 {% if debater_obj %}
 
 <div class="col-md-6">
+  {% if user.is_superuser %}
   <div class="team-record">
     <h5>Debater Rounds</h5>
     <table class="table table-striped">
@@ -26,6 +27,7 @@
       {% endfor %}
     </table>
   </div>
+  {% endif %}
   
   {% if team_schools %}
   <div class="team-record mt-4">
@@ -50,7 +52,7 @@
     </table>
   </div>
   {% endif %}
-  {% if debater_obj.ranking_groups.count %}
+  {% if user.is_superuser and debater_obj.ranking_groups.count %}
   <div class="team-record mt-4">
     <h5>Ranking Groups</h5>
     <ul class="list-unstyled mb-0">

--- a/mittab/templates/tab/invite_staff.html
+++ b/mittab/templates/tab/invite_staff.html
@@ -13,11 +13,44 @@
   </form>
 </div>
 <div class="col-md-6">
-  <p>
+  <p class="text-muted">
     Invited users receive a single-use password setup link using Django's
     built-in password reset tokens. The username entered here is the username
-    they will use to sign in. New invited accounts are created as full tab
-    staff accounts with no usable password until the recipient sets one.
+    they will use to sign in. New invited accounts are created with the selected
+    permission preset and no usable password until the recipient sets one.
   </p>
+  <h5>Permission Presets</h5>
+  <div class="list-group">
+    {% for preset in staff_preset_details %}
+    <div class="list-group-item">
+      <div class="d-flex justify-content-between align-items-start">
+        <div>
+          <h6 class="mb-1">{{ preset.label }}</h6>
+          <p class="mb-2 text-muted">{{ preset.summary }}</p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6">
+          <strong>Can</strong>
+          <ul class="mb-2 pl-3">
+            {% for item in preset.can %}
+            <li>{{ item }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% if preset.cannot %}
+        <div class="col-md-6">
+          <strong>Cannot</strong>
+          <ul class="mb-0 pl-3">
+            {% for item in preset.cannot %}
+            <li>{{ item }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
 </div>
 {% endblock %}

--- a/mittab/templates/tab/judge_detail.html
+++ b/mittab/templates/tab/judge_detail.html
@@ -3,7 +3,7 @@
 {% block detail_content %}
 <div class="col-md-1"></div>
 <div class="col-md-5">
-  {% if judge_rounds %}
+  {% if user.is_superuser and judge_rounds %}
   <div class="team-record">
     <h5>Rounds Judged</h5>
     <table class="table table-striped">

--- a/mittab/templates/tab/room_detail.html
+++ b/mittab/templates/tab/room_detail.html
@@ -1,6 +1,7 @@
 {% extends "common/data_entry.html" %}
 
 {% block detail_content %}
+{% if user.is_superuser %}
 {% if room_rounds or room_outrounds %}
 <div class="col-md-1"></div>
 <div class="col-md-5">
@@ -52,5 +53,6 @@
   </div>
   {% endif %}
 </div>
+{% endif %}
 {% endif %}
 {% endblock %}

--- a/mittab/templates/tab/team_detail.html
+++ b/mittab/templates/tab/team_detail.html
@@ -4,6 +4,7 @@
 {% if team_obj %}
 <div class="col-md-1"></div>
 <div class="col-md-5">
+  {% if user.is_superuser %}
   <div class="team-record">
     <h5>Team Stats</h5>
     <table class="table table-striped">
@@ -14,6 +15,7 @@
     </table>
     <a href='/team/card/{{ team_obj.id }}/pretty/' class="btn btn-link">View Tab Card</a>
   </div>
+  {% endif %}
   
   <div class="team-record mt-4">
     <h5>Team Details</h5>
@@ -26,7 +28,7 @@
           {% endfor %}
         </td>
       </tr>
-      {% if team_obj.ranking_groups.count %}
+      {% if user.is_superuser and team_obj.ranking_groups.count %}
       <tr>
         <td>Ranking Groups</td>
         <td>

--- a/mittab/urls.py
+++ b/mittab/urls.py
@@ -77,6 +77,7 @@ urlpatterns = [
 
     # Judge related
     re_path(r"^judge/(\d+)/$", judge_views.view_judge, name="view_judge"),
+    re_path(r"^judge/(\d+)/delete/$", judge_views.delete_judge, name="delete_judge"),
     re_path(r"^judge/(\d+)/scratches/add/(\d+)/",
             judge_views.add_scratches,
             name="add_scratches"),
@@ -100,6 +101,7 @@ urlpatterns = [
 
     # Room related
     re_path(r"^room/(\d+)/$", views.view_room, name="view_room"),
+    re_path(r"^room/(\d+)/delete/$", views.delete_room, name="delete_room"),
     path("view_rooms/", views.view_rooms, name="view_rooms"),
     path("enter_room/", views.enter_room, name="enter_room"),
 
@@ -126,6 +128,7 @@ urlpatterns = [
 
     # Team related
     re_path(r"^team/(\d+)/$", team_views.view_team, name="view_team"),
+    re_path(r"^team/(\d+)/delete/$", team_views.delete_team, name="delete_team"),
     re_path(r"^team/(\d+)/scratches/add/(\d+)/",
             team_views.add_scratches,
             name="add_scratches"),
@@ -145,6 +148,9 @@ urlpatterns = [
 
     # Debater related
     re_path(r"^debater/(\d+)/$", debater_views.view_debater, name="view_debater"),
+    re_path(r"^debater/(\d+)/delete/$",
+            debater_views.delete_debater,
+            name="delete_debater"),
     path("view_debaters/", debater_views.view_debaters,
          name="view_debaters"),
     path("enter_debater/", debater_views.enter_debater,


### PR DESCRIPTION
## Summary
- add centralized staff permission presets and capability checks
- add invite-page preset dropdown with role descriptions
- enforce restricted staff access and role-specific login landing pages
- hide unauthorized navigation, scratch, check-in, upload, and data-entry controls

## Validation
- pipenv run pylint mittab
- npm run lint
- pipenv run pytest mittab/libs/tests/views/test_tab_views.py::TestTabViews::test_restricted_staff_login_redirects_to_accessible_landing_page mittab/libs/tests/views/test_tab_views.py::TestTabViews::test_restricted_staff_login_honors_accessible_next_page -q

## Notes
- Local broader Django view tests currently hit a stale webpack stats issue: webpack tries to resolve ./assets/js/emailManagement after moving this branch back to master, where that email-management bundle is not present.