### PR TITLE
Redirect board users past tournament checklist

### DIFF
--- a/mittab/apps/tab/views/tournament_todo_views.py
+++ b/mittab/apps/tab/views/tournament_todo_views.py
@@ -3,6 +3,7 @@ from django.http import JsonResponse
 from django.shortcuts import redirect, render, reverse
 
 from mittab.apps.tab.auth_roles import (
+    is_apda_board_user,
     is_restricted_staff_user,
     restricted_staff_can_access_path,
     restricted_staff_landing_url,
@@ -29,6 +30,11 @@ class StaffLoginView(LoginView):
 
     def get_success_url(self):
         redirect_url = self.get_redirect_url()
+        if is_apda_board_user(self.request.user) and (
+            not redirect_url or redirect_url == reverse("tournament_todo")
+        ):
+            return reverse("apda_board_home")
+
         if redirect_url:
             if is_restricted_staff_user(self.request.user):
                 if restricted_staff_can_access_path(self.request.user, redirect_url):

--- a/mittab/libs/tests/views/test_tournament_todo.py
+++ b/mittab/libs/tests/views/test_tournament_todo.py
@@ -6,9 +6,11 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.test import Client, TestCase
 from django.urls import reverse
 
+from mittab.apps.tab.auth_roles import APDA_BOARD_GROUP_NAME
 from mittab.apps.tab.models import (
     DEFAULT_TOURNAMENT_NAME,
     TabSettings,
@@ -36,6 +38,42 @@ class TestTournamentTodo(TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], reverse("tournament_todo"))
+
+    def test_board_login_redirects_to_board_home(self):
+        group = Group.objects.create(name=APDA_BOARD_GROUP_NAME)
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        self.user.groups.add(group)
+
+        with patch(
+            "mittab.apps.tab.auth_backends.is_apda_board_access_open",
+            return_value=True,
+        ):
+            response = self.client.post(
+                reverse("tab_login"),
+                {"username": "todo_user", "password": "todo_pass_123"},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("apda_board_home"))
+
+    def test_board_login_skips_explicit_todo_redirect(self):
+        group = Group.objects.create(name=APDA_BOARD_GROUP_NAME)
+        self.user.is_superuser = False
+        self.user.save(update_fields=["is_superuser"])
+        self.user.groups.add(group)
+
+        with patch(
+            "mittab.apps.tab.auth_backends.is_apda_board_access_open",
+            return_value=True,
+        ):
+            response = self.client.post(
+                f'{reverse("tab_login")}?next={reverse("tournament_todo")}',
+                {"username": "todo_user", "password": "todo_pass_123"},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("apda_board_home"))
 
     def test_login_accepts_https_origin_behind_proxy(self):
         client = Client(enforce_csrf_checks=True)


### PR DESCRIPTION
## Summary
- send APDA Board users directly to the board home after login
- bypass stale explicit tournament-checklist redirects for board users
- cover default and explicit checklist login destinations with regression tests

## Testing
- `uv run pytest mittab/libs/tests/views/test_tournament_todo.py`
- `uv run python bin/check-dependency-age`
- `uv run pylint mittab`
- `npm run lint`